### PR TITLE
fix: remove aqua-local.yaml

### DIFF
--- a/pkg/initcmd/init.go
+++ b/pkg/initcmd/init.go
@@ -15,9 +15,6 @@ func Init(ctx context.Context) error {
 	if err := initAquaYAML(); err != nil {
 		return err
 	}
-	if err := initAquaLocalYAML(); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -36,21 +33,6 @@ registries:
 packages:
 `), filePermission); err != nil {
 		return fmt.Errorf("create aqua.yaml: %w", err)
-	}
-	return nil
-}
-
-func initAquaLocalYAML() error {
-	if _, err := os.Stat("aqua-local.yaml"); err == nil {
-		return nil
-	}
-	fmt.Fprintln(os.Stderr, "Creating aqua-local.yaml")
-	if err := os.WriteFile("aqua-local.yaml", []byte(`---
-# aqua - Declarative CLI Version Manager
-# https://aquaproj.github.io/
-packages:
-`), filePermission); err != nil {
-		return fmt.Errorf("create aqua-local.yaml: %w", err)
 	}
 	return nil
 }

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -41,9 +41,6 @@ e.g. $ aqua-registry scaffold cli/cli`)
 	if err := initcmd.Init(ctx); err != nil {
 		return err //nolint:wrapcheck
 	}
-	if err := aquaG(pkgFile); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -71,14 +68,6 @@ func aquaGR(ctx context.Context, pkgName, pkgFilePath, rgFilePath string, cmds s
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("execute a command: %w", err)
-	}
-	return nil
-}
-
-func aquaG(pkgFilePath string) error {
-	fmt.Fprintf(os.Stderr, "appending '- import: %s' to aqua-local.yaml\n", pkgFilePath)
-	if err := generateInsert("aqua-local.yaml", pkgFilePath); err != nil {
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
aqua-local.yaml is unnecessary anymore.
We test packages in the container.