### PR TITLE
fix: redact secret env values in docker exec logs

### DIFF
--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -229,7 +229,7 @@ func runAquaGRInContainer(ctx context.Context, logger *slog.Logger, dm *DockerMa
 	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
 	setCancel(logger, cmd)
-	logger.Info("+ " + cmd.String())
+	logger.Info("+ " + redactSecrets(cmd.String(), env))
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker exec: %w", err)
 	}

--- a/pkg/scaffold/docker.go
+++ b/pkg/scaffold/docker.go
@@ -144,7 +144,7 @@ func (dm *DockerManager) Exec(ctx context.Context, logger *slog.Logger, env map[
 	args = append(args, command...)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
-	logger.Info("+ " + cmd.String())
+	logger.Info("+ " + redactSecrets(cmd.String(), env))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	setCancel(logger, cmd)
@@ -382,6 +382,15 @@ func copyFile(src, dst string) error {
 		return err //nolint:wrapcheck
 	}
 	return os.WriteFile(dst, data, filePermission) //nolint:wrapcheck
+}
+
+func redactSecrets(s string, env map[string]string) string {
+	for _, v := range env {
+		if v != "" {
+			s = strings.ReplaceAll(s, v, "<REDACTED>")
+		}
+	}
+	return s
 }
 
 func isPodman(ctx context.Context, logger *slog.Logger) bool {


### PR DESCRIPTION
## Summary
- Fix secret values (e.g. `GITHUB_TOKEN`) being logged in plain text in `docker exec` command output
- Add `redactSecrets` helper function that replaces env map values with `<REDACTED>` before logging
- Apply redaction in both `Exec` method (`pkg/scaffold/docker.go`) and `runAquaGRInContainer` (`pkg/scaffold/api.go`)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/scaffold/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)