### PR TITLE
feat: port new.sh pre-flight checks into create-pr-new-pkg command

### DIFF
--- a/pkg/create-pr-new-pkg/api.go
+++ b/pkg/create-pr-new-pkg/api.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/aquaproj/registry-tool/pkg/initcmd"
+	"github.com/aquaproj/registry-tool/pkg/osexec"
 	"gopkg.in/yaml.v3"
 )
 
@@ -22,11 +23,11 @@ var bodyTemplate []byte
 
 func CreatePRNewPkgs(ctx context.Context, logger *slog.Logger, pkgName string) error {
 	pkgName = strings.TrimPrefix(pkgName, "https://github.com/")
-	if err := checkDiffPackage(ctx); err != nil {
+	if err := checkDiffPackage(ctx, logger); err != nil {
 		return err
 	}
 	var err error
-	pkgName, err = getPkgFromBranch(ctx, pkgName)
+	pkgName, err = getPkgFromBranch(ctx, logger, pkgName)
 	if err != nil {
 		return err
 	}
@@ -103,16 +104,20 @@ func getBody(pkgName, desc string) string {
 	return fmt.Sprintf(`%s: %s`, pkgName, desc)
 }
 
-func checkDiffPackage(ctx context.Context) error {
+func checkDiffPackage(ctx context.Context, logger *slog.Logger) error {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--quiet", "pkgs", "registry.yaml")
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return errors.New("there are unstaged changes in pkgs or registry.yaml")
 	}
 	cmd = exec.CommandContext(ctx, "git", "diff", "--cached", "--quiet", "pkgs", "registry.yaml")
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return errors.New("there are staged changes in pkgs or registry.yaml")
 	}
-	out, err := exec.CommandContext(ctx, "git", "ls-files", "--others", "--exclude-standard", "pkgs").Output()
+	cmd = exec.CommandContext(ctx, "git", "ls-files", "--others", "--exclude-standard", "pkgs")
+	osexec.SetCancel(logger, cmd)
+	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("check untracked files in pkgs: %w", err)
 	}
@@ -122,8 +127,10 @@ func checkDiffPackage(ctx context.Context) error {
 	return nil
 }
 
-func getPkgFromBranch(ctx context.Context, pkgName string) (string, error) {
-	out, err := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+func getPkgFromBranch(ctx context.Context, logger *slog.Logger, pkgName string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	osexec.SetCancel(logger, cmd)
+	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("get current branch: %w", err)
 	}

--- a/pkg/osexec/cancel.go
+++ b/pkg/osexec/cancel.go
@@ -1,4 +1,4 @@
-package scaffold
+package osexec
 
 import (
 	"log/slog"
@@ -9,7 +9,7 @@ import (
 
 const defaultWaitDelay = 1000 * time.Hour
 
-func setCancel(logger *slog.Logger, cmd *exec.Cmd) {
+func SetCancel(logger *slog.Logger, cmd *exec.Cmd) {
 	cmd.Cancel = func() error {
 		logger.Warn("SIGINT is sent to cancel the command")
 		return cmd.Process.Signal(os.Interrupt)

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -15,6 +15,7 @@ import (
 
 	genrg "github.com/aquaproj/registry-tool/pkg/generate-registry"
 	"github.com/aquaproj/registry-tool/pkg/initcmd"
+	"github.com/aquaproj/registry-tool/pkg/osexec"
 )
 
 const (
@@ -228,7 +229,7 @@ func runAquaGRInContainer(ctx context.Context, logger *slog.Logger, dm *DockerMa
 	buf := &bytes.Buffer{}
 	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	logger.Info("+ " + redactSecrets(cmd.String(), env))
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker exec: %w", err)
@@ -287,7 +288,7 @@ func aquaGR(ctx context.Context, logger *slog.Logger, pkgName, pkgFilePath, rgFi
 	cmd := exec.CommandContext(ctx, "aqua", append(args, pkgName)...) //nolint:gosec
 	cmd.Stdout = outFile
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	logger.Info("+ " + cmd.String())
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("execute a command: %w", err)

--- a/pkg/scaffold/docker.go
+++ b/pkg/scaffold/docker.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/aquaproj/registry-tool/pkg/osexec"
 )
 
 // DockerManager manages Docker container operations.
@@ -67,7 +69,7 @@ func (dm *DockerManager) ContainerExists(ctx context.Context, logger *slog.Logge
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return false, fmt.Errorf("docker ps: %w", err)
 	}
@@ -90,7 +92,7 @@ func (dm *DockerManager) ContainerRunning(ctx context.Context, logger *slog.Logg
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return false, fmt.Errorf("docker ps: %w", err)
 	}
@@ -117,14 +119,14 @@ func (dm *DockerManager) RemoveContainer(ctx context.Context, logger *slog.Logge
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	_ = cmd.Run() // Ignore error if container is not running
 
 	cmd = exec.CommandContext(ctx, "docker", "rm", dm.config.Name) //nolint:gosec
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker rm: %w", err)
 	}
@@ -147,7 +149,7 @@ func (dm *DockerManager) Exec(ctx context.Context, logger *slog.Logger, env map[
 	logger.Info("+ " + redactSecrets(cmd.String(), env))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker exec: %w", err)
 	}
@@ -166,7 +168,7 @@ func (dm *DockerManager) CopyTo(ctx context.Context, logger *slog.Logger, src, d
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker cp to container: %w", err)
 	}
@@ -180,7 +182,7 @@ func (dm *DockerManager) CopyFrom(ctx context.Context, logger *slog.Logger, src,
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker cp from container: %w", err)
 	}
@@ -238,7 +240,7 @@ func (dm *DockerManager) imageExists(ctx context.Context, logger *slog.Logger) b
 	cmd := exec.CommandContext(ctx, "docker", "inspect", dm.config.Image) //nolint:gosec
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	return cmd.Run() == nil
 }
 
@@ -270,7 +272,7 @@ func (dm *DockerManager) buildImage(ctx context.Context, logger *slog.Logger) er
 	cmd := exec.CommandContext(ctx, "docker", "build", "-t", dm.config.Image, "docker") //nolint:gosec
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker build: %w", err)
 	}
@@ -305,7 +307,7 @@ func (dm *DockerManager) getContainerImageID(ctx context.Context, logger *slog.L
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("docker inspect container: %w", err)
 	}
@@ -327,7 +329,7 @@ func (dm *DockerManager) getImageID(ctx context.Context, logger *slog.Logger) (s
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("docker inspect image: %w", err)
 	}
@@ -357,7 +359,7 @@ func (dm *DockerManager) runContainer(ctx context.Context, logger *slog.Logger) 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker run: %w", err)
 	}
@@ -369,7 +371,7 @@ func (dm *DockerManager) startContainer(ctx context.Context, logger *slog.Logger
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker start: %w", err)
 	}
@@ -398,7 +400,7 @@ func isPodman(ctx context.Context, logger *slog.Logger) bool {
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = nil
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return false
 	}

--- a/pkg/scaffold/git.go
+++ b/pkg/scaffold/git.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/aquaproj/registry-tool/pkg/osexec"
 )
 
 // GitCheckout creates or switches to a feature branch for the package.
@@ -29,7 +31,7 @@ func branchExists(ctx context.Context, logger *slog.Logger, branch string) bool 
 	cmd := exec.CommandContext(ctx, "git", "show-ref", "--quiet", "refs/heads/"+branch) //nolint:gosec
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	return cmd.Run() == nil
 }
 
@@ -37,7 +39,7 @@ func gitCheckoutBranch(ctx context.Context, logger *slog.Logger, branch string) 
 	cmd := exec.CommandContext(ctx, "git", "checkout", branch)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	logger.Info("+ " + cmd.String())
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("git checkout %s: %w", branch, err)
@@ -54,7 +56,7 @@ func createBranchFromUpstream(ctx context.Context, logger *slog.Logger, branch s
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("git remote add: %w", err)
 	}
@@ -65,7 +67,7 @@ func createBranchFromUpstream(ctx context.Context, logger *slog.Logger, branch s
 		logger.Info("+ " + rmCmd.String())
 		rmCmd.Stdout = os.Stdout
 		rmCmd.Stderr = os.Stderr
-		setCancel(logger, rmCmd)
+		osexec.SetCancel(logger, rmCmd)
 		_ = rmCmd.Run()
 	}()
 
@@ -74,7 +76,7 @@ func createBranchFromUpstream(ctx context.Context, logger *slog.Logger, branch s
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("git fetch: %w", err)
 	}
@@ -84,7 +86,7 @@ func createBranchFromUpstream(ctx context.Context, logger *slog.Logger, branch s
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("git checkout -b: %w", err)
 	}
@@ -100,7 +102,7 @@ func GitCommit(ctx context.Context, logger *slog.Logger, pkgName string) error {
 	cmd := exec.CommandContext(ctx, "git", "add", "registry.yaml", pkgDir)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("git add: %w", err)
 	}
@@ -112,7 +114,7 @@ func GitCommit(ctx context.Context, logger *slog.Logger, pkgName string) error {
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("git commit: %w", err)
 	}
@@ -126,7 +128,7 @@ func GetCurrentBranch(ctx context.Context, logger *slog.Logger) (string, error) 
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("git rev-parse: %w", err)
 	}

--- a/pkg/scaffold/prereq.go
+++ b/pkg/scaffold/prereq.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/aquaproj/registry-tool/pkg/osexec"
 )
 
 // CheckPrerequisites checks if required commands are available.
@@ -28,7 +30,7 @@ func CheckPrerequisites(ctx context.Context, logger *slog.Logger) error {
 
 func checkCommand(ctx context.Context, logger *slog.Logger, name string) error {
 	cmd := exec.CommandContext(ctx, name, "--version")
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run() //nolint:wrapcheck
@@ -62,7 +64,7 @@ func gitDiffQuiet(ctx context.Context, logger *slog.Logger, path string) error {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--quiet", path)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	return cmd.Run() //nolint:wrapcheck
 }
 
@@ -70,7 +72,7 @@ func gitDiffCachedQuiet(ctx context.Context, logger *slog.Logger, path string) e
 	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--quiet", path)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	return cmd.Run() //nolint:wrapcheck
 }
 
@@ -79,7 +81,7 @@ func gitLsFilesOthers(ctx context.Context, logger *slog.Logger, path string) ([]
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
-	setCancel(logger, cmd)
+	osexec.SetCancel(logger, cmd)
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("git ls-files: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Strip `https://github.com/` prefix from package name, matching `new.sh` behavior
- Add `checkDiffPackage` to validate no uncommitted changes in `pkgs/` or `registry.yaml` (replaces `check_diff_package.sh`)
- Add `getPkgFromBranch` to validate `feat/<pkg>` branch and derive package name when not provided (replaces `get_pkg_from_branch.sh`)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/create-pr-new-pkg/...` passes
- [x] `golangci-lint run` passes
- [ ] Manual test: run `create-pr-new-pkg` on a `feat/<pkg>` branch with no args — should derive pkg from branch
- [ ] Manual test: run with `https://github.com/owner/repo` — should strip prefix
- [ ] Manual test: run with uncommitted changes in `pkgs/` — should error

🤖 Generated with [Claude Code](https://claude.com/claude-code)