### PR TITLE
feat: add resolve-conflict command

### DIFF
--- a/pkg/cli/resolveconflict/command.go
+++ b/pkg/cli/resolveconflict/command.go
@@ -1,0 +1,20 @@
+package resolveconflict
+
+import (
+	"context"
+	"log/slog"
+
+	rc "github.com/aquaproj/registry-tool/pkg/resolve-conflict"
+	"github.com/urfave/cli/v3"
+)
+
+func Command(logger *slog.Logger) *cli.Command {
+	return &cli.Command{
+		Name:      "resolve-conflict",
+		Usage:     "Resolve registry.yaml merge conflict with main",
+		UsageText: "aqua-registry resolve-conflict <PR number>",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return rc.ResolveConflict(ctx, logger, cmd.Args().First())
+		},
+	}
+}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aquaproj/registry-tool/pkg/cli/initcmd"
 	"github.com/aquaproj/registry-tool/pkg/cli/mv"
 	"github.com/aquaproj/registry-tool/pkg/cli/patchchecksum"
+	"github.com/aquaproj/registry-tool/pkg/cli/resolveconflict"
 	"github.com/aquaproj/registry-tool/pkg/cli/scaffold"
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
@@ -39,6 +40,7 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 			patchchecksum.Command(logger.Logger),
 			checkrepo.Command(),
 			mv.Command(),
+			resolveconflict.Command(logger.Logger),
 		},
 	}).Run(ctx, env.Args)
 }

--- a/pkg/resolve-conflict/resolve.go
+++ b/pkg/resolve-conflict/resolve.go
@@ -1,0 +1,117 @@
+package resolveconflict
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+
+	genrg "github.com/aquaproj/registry-tool/pkg/generate-registry"
+	"github.com/aquaproj/registry-tool/pkg/osexec"
+)
+
+func ResolveConflict(ctx context.Context, logger *slog.Logger, prNumber string) error {
+	if prNumber == "" {
+		return errors.New("PR number is required")
+	}
+
+	// Fetch origin main
+	if err := run(ctx, logger, "git", "fetch", "origin", "main"); err != nil {
+		return err
+	}
+
+	// Checkout the PR
+	if err := run(ctx, logger, "aqua", "-c", "aqua/dev.yaml", "exec", "--", "gh", "pr", "checkout", prNumber); err != nil {
+		return err
+	}
+
+	// Merge main with registry.yaml backup/restore
+	if err := mergeMainWithBackup(ctx, logger); err != nil {
+		return err
+	}
+
+	// Stage registry.yaml
+	if err := run(ctx, logger, "git", "add", "registry.yaml"); err != nil {
+		return err
+	}
+
+	// Interactive commit
+	commitCmd := exec.CommandContext(ctx, "git", "commit")
+	commitCmd.Stdout = os.Stdout
+	commitCmd.Stderr = os.Stderr
+	commitCmd.Stdin = os.Stdin
+	osexec.SetCancel(logger, commitCmd)
+	logger.Info("+ " + commitCmd.String())
+	if err := commitCmd.Run(); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+
+	return nil
+}
+
+func mergeMainWithBackup(ctx context.Context, logger *slog.Logger) error {
+	// Copy registry.yaml to a temp file
+	tmpFile, err := os.CreateTemp("", "registry-*.yaml")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if err := copyFile("registry.yaml", tmpFile.Name()); err != nil {
+		return fmt.Errorf("backup registry.yaml: %w", err)
+	}
+
+	// Merge origin/main — conflict is expected, so ignore the error
+	cmd := exec.CommandContext(ctx, "git", "merge", "origin/main")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	osexec.SetCancel(logger, cmd)
+	logger.Info("+ " + cmd.String())
+	_ = cmd.Run()
+
+	// Restore registry.yaml from temp file
+	if err := copyFile(tmpFile.Name(), "registry.yaml"); err != nil {
+		return fmt.Errorf("restore registry.yaml: %w", err)
+	}
+
+	// Regenerate registry.yaml
+	if err := genrg.GenerateRegistry(); err != nil {
+		return fmt.Errorf("generate registry: %w", err)
+	}
+
+	return nil
+}
+
+func run(ctx context.Context, logger *slog.Logger, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	osexec.SetCancel(logger, cmd)
+	logger.Info("+ " + cmd.String())
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w", cmd.String(), err)
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copy %s to %s: %w", src, dst, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add new `resolve-conflict` command to automate resolving `registry.yaml` merge conflicts with main
- Checks out a PR via `gh`, backs up `registry.yaml`, merges `origin/main`, restores the backup, regenerates via `GenerateRegistry()`, and opens an interactive commit
- New files: `pkg/resolve-conflict/resolve.go` (business logic), `pkg/cli/resolveconflict/command.go` (CLI wiring)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -race -covermode=atomic` passes
- [x] `golangci-lint run` passes (0 issues)
- [ ] Manual test: `aqua-registry resolve-conflict <PR number>` on a PR with a registry.yaml conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)