### PR TITLE
feat: add start command

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aquaproj/registry-tool/pkg/cli/patchchecksum"
 	"github.com/aquaproj/registry-tool/pkg/cli/resolveconflict"
 	"github.com/aquaproj/registry-tool/pkg/cli/scaffold"
+	startcmd "github.com/aquaproj/registry-tool/pkg/cli/start"
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
 	"github.com/urfave/cli/v3"
@@ -41,6 +42,7 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 			checkrepo.Command(),
 			mv.Command(),
 			resolveconflict.Command(logger.Logger),
+			startcmd.Command(logger.Logger),
 		},
 	}).Run(ctx, env.Args)
 }

--- a/pkg/cli/start/command.go
+++ b/pkg/cli/start/command.go
@@ -1,0 +1,29 @@
+package start
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aquaproj/registry-tool/pkg/start"
+	"github.com/urfave/cli/v3"
+)
+
+func Command(logger *slog.Logger) *cli.Command {
+	var recreate bool
+	return &cli.Command{
+		Name:      "start",
+		Usage:     "Start Docker containers",
+		UsageText: "aqua-registry start [-r]",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "recreate",
+				Aliases:     []string{"r"},
+				Usage:       "Recreate the containers",
+				Destination: &recreate,
+			},
+		},
+		Action: func(ctx context.Context, _ *cli.Command) error {
+			return start.Start(ctx, logger, recreate)
+		},
+	}
+}

--- a/pkg/docker/config.go
+++ b/pkg/docker/config.go
@@ -1,0 +1,37 @@
+package docker
+
+import "os"
+
+// Config holds Docker container configuration.
+type Config struct {
+	Name       string
+	Image      string
+	WorkingDir string
+}
+
+const (
+	// ContainerWorkingDir is the default working directory inside containers.
+	ContainerWorkingDir = "/workspace"
+	// DirPermission is the default permission for directories.
+	DirPermission os.FileMode = 0o775
+	// FilePermission is the default permission for files.
+	FilePermission os.FileMode = 0o644
+)
+
+// DefaultLinuxContainer returns the default Linux container configuration.
+func DefaultLinuxContainer() Config {
+	return Config{
+		Name:       "aqua-registry",
+		Image:      "aquaproj/aqua-registry",
+		WorkingDir: ContainerWorkingDir,
+	}
+}
+
+// DefaultWindowsContainer returns the default Windows container configuration.
+func DefaultWindowsContainer() Config {
+	return Config{
+		Name:       "aqua-registry-windows",
+		Image:      "aquaproj/aqua-registry",
+		WorkingDir: ContainerWorkingDir,
+	}
+}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -1,4 +1,4 @@
-package scaffold
+package docker
 
 import (
 	"bytes"
@@ -14,19 +14,24 @@ import (
 	"github.com/aquaproj/registry-tool/pkg/osexec"
 )
 
-// DockerManager manages Docker container operations.
-type DockerManager struct {
-	config ContainerConfig
+// Manager manages Docker container operations.
+type Manager struct {
+	config Config
 }
 
-// NewDockerManager creates a new DockerManager with the given configuration.
-func NewDockerManager(config ContainerConfig) *DockerManager {
-	return &DockerManager{config: config}
+// NewManager creates a new Manager with the given configuration.
+func NewManager(config Config) *Manager {
+	return &Manager{config: config}
+}
+
+// Config returns the container configuration.
+func (dm *Manager) Config() Config {
+	return dm.config
 }
 
 // EnsureContainer ensures the container is running.
 // If recreate is true, it will stop and remove the existing container first.
-func (dm *DockerManager) EnsureContainer(ctx context.Context, logger *slog.Logger, recreate bool) error {
+func (dm *Manager) EnsureContainer(ctx context.Context, logger *slog.Logger, recreate bool) error {
 	if recreate {
 		if err := dm.RemoveContainer(ctx, logger); err != nil {
 			return err
@@ -61,7 +66,7 @@ func (dm *DockerManager) EnsureContainer(ctx context.Context, logger *slog.Logge
 }
 
 // ContainerExists checks if the container exists.
-func (dm *DockerManager) ContainerExists(ctx context.Context, logger *slog.Logger) (bool, error) {
+func (dm *Manager) ContainerExists(ctx context.Context, logger *slog.Logger) (bool, error) {
 	logger.Info("checking if the container exists", "container_name", dm.config.Name)
 	cmd := exec.CommandContext(ctx, "docker", "ps", "-a", //nolint:gosec
 		"--filter", "name="+dm.config.Name,
@@ -83,7 +88,7 @@ func (dm *DockerManager) ContainerExists(ctx context.Context, logger *slog.Logge
 }
 
 // ContainerRunning checks if the container is running.
-func (dm *DockerManager) ContainerRunning(ctx context.Context, logger *slog.Logger) (bool, error) {
+func (dm *Manager) ContainerRunning(ctx context.Context, logger *slog.Logger) (bool, error) {
 	logger.Info("checking if the container is running", "container_name", dm.config.Name)
 	cmd := exec.CommandContext(ctx, "docker", "ps", "-a", //nolint:gosec
 		"--filter", "name="+dm.config.Name,
@@ -106,7 +111,7 @@ func (dm *DockerManager) ContainerRunning(ctx context.Context, logger *slog.Logg
 }
 
 // RemoveContainer stops and removes the container.
-func (dm *DockerManager) RemoveContainer(ctx context.Context, logger *slog.Logger) error {
+func (dm *Manager) RemoveContainer(ctx context.Context, logger *slog.Logger) error {
 	exists, err := dm.ContainerExists(ctx, logger)
 	if err != nil {
 		return err
@@ -134,7 +139,7 @@ func (dm *DockerManager) RemoveContainer(ctx context.Context, logger *slog.Logge
 }
 
 // Exec executes a command in the container.
-func (dm *DockerManager) Exec(ctx context.Context, logger *slog.Logger, env map[string]string, command ...string) error {
+func (dm *Manager) Exec(ctx context.Context, logger *slog.Logger, env map[string]string, command ...string) error {
 	args := []string{"exec"}
 	if dm.config.WorkingDir != "" {
 		args = append(args, "-w", dm.config.WorkingDir)
@@ -146,7 +151,7 @@ func (dm *DockerManager) Exec(ctx context.Context, logger *slog.Logger, env map[
 	args = append(args, command...)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
-	logger.Info("+ " + redactSecrets(cmd.String(), env))
+	logger.Info("+ " + RedactSecrets(cmd.String(), env))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	osexec.SetCancel(logger, cmd)
@@ -157,12 +162,12 @@ func (dm *DockerManager) Exec(ctx context.Context, logger *slog.Logger, env map[
 }
 
 // ExecBash executes a bash command in the container.
-func (dm *DockerManager) ExecBash(ctx context.Context, logger *slog.Logger, bashCmd string) error {
+func (dm *Manager) ExecBash(ctx context.Context, logger *slog.Logger, bashCmd string) error {
 	return dm.Exec(ctx, logger, nil, "bash", "-c", bashCmd)
 }
 
 // CopyTo copies a file from the host to the container.
-func (dm *DockerManager) CopyTo(ctx context.Context, logger *slog.Logger, src, dst string) error {
+func (dm *Manager) CopyTo(ctx context.Context, logger *slog.Logger, src, dst string) error {
 	containerPath := dm.config.Name + ":" + dst
 	cmd := exec.CommandContext(ctx, "docker", "cp", src, containerPath)
 	logger.Info("+ " + cmd.String())
@@ -176,7 +181,7 @@ func (dm *DockerManager) CopyTo(ctx context.Context, logger *slog.Logger, src, d
 }
 
 // CopyFrom copies a file from the container to the host.
-func (dm *DockerManager) CopyFrom(ctx context.Context, logger *slog.Logger, src, dst string) error {
+func (dm *Manager) CopyFrom(ctx context.Context, logger *slog.Logger, src, dst string) error {
 	containerPath := dm.config.Name + ":" + src
 	cmd := exec.CommandContext(ctx, "docker", "cp", containerPath, dst)
 	logger.Info("+ " + cmd.String())
@@ -189,7 +194,7 @@ func (dm *DockerManager) CopyFrom(ctx context.Context, logger *slog.Logger, src,
 	return nil
 }
 
-func (dm *DockerManager) handleRunningContainer(ctx context.Context, logger *slog.Logger) error {
+func (dm *Manager) handleRunningContainer(ctx context.Context, logger *slog.Logger) error {
 	upToDate, err := dm.checkImageUpToDate(ctx, logger)
 	if err != nil {
 		return err
@@ -205,7 +210,7 @@ func (dm *DockerManager) handleRunningContainer(ctx context.Context, logger *slo
 	return dm.runContainer(ctx, logger)
 }
 
-func (dm *DockerManager) handleStoppedContainer(ctx context.Context, logger *slog.Logger) error {
+func (dm *Manager) handleStoppedContainer(ctx context.Context, logger *slog.Logger) error {
 	upToDate, err := dm.checkImageUpToDate(ctx, logger)
 	if err != nil {
 		return err
@@ -223,7 +228,7 @@ func (dm *DockerManager) handleStoppedContainer(ctx context.Context, logger *slo
 	return dm.runContainer(ctx, logger)
 }
 
-func (dm *DockerManager) ensureImage(ctx context.Context, logger *slog.Logger) error {
+func (dm *Manager) ensureImage(ctx context.Context, logger *slog.Logger) error {
 	notChanged, err := dm.dockerfileNotChanged()
 	if err != nil {
 		return err
@@ -236,7 +241,7 @@ func (dm *DockerManager) ensureImage(ctx context.Context, logger *slog.Logger) e
 	return dm.buildImage(ctx, logger)
 }
 
-func (dm *DockerManager) imageExists(ctx context.Context, logger *slog.Logger) bool {
+func (dm *Manager) imageExists(ctx context.Context, logger *slog.Logger) bool {
 	cmd := exec.CommandContext(ctx, "docker", "inspect", dm.config.Image) //nolint:gosec
 	cmd.Stdout = nil
 	cmd.Stderr = nil
@@ -244,7 +249,7 @@ func (dm *DockerManager) imageExists(ctx context.Context, logger *slog.Logger) b
 	return cmd.Run() == nil
 }
 
-func (dm *DockerManager) dockerfileNotChanged() (bool, error) {
+func (dm *Manager) dockerfileNotChanged() (bool, error) {
 	// Check if .build/Dockerfile exists
 	if _, err := os.Stat(".build/Dockerfile"); os.IsNotExist(err) {
 		return false, nil
@@ -262,9 +267,9 @@ func (dm *DockerManager) dockerfileNotChanged() (bool, error) {
 	return string(b1) == string(b2), nil
 }
 
-func (dm *DockerManager) buildImage(ctx context.Context, logger *slog.Logger) error {
+func (dm *Manager) buildImage(ctx context.Context, logger *slog.Logger) error {
 	// Copy aqua-policy.yaml to docker directory
-	if err := copyFile("aqua-policy.yaml", "docker/aqua-policy.yaml"); err != nil {
+	if err := CopyFile("aqua-policy.yaml", "docker/aqua-policy.yaml"); err != nil {
 		return fmt.Errorf("copy aqua-policy.yaml: %w", err)
 	}
 
@@ -278,17 +283,17 @@ func (dm *DockerManager) buildImage(ctx context.Context, logger *slog.Logger) er
 	}
 
 	// Save Dockerfile to .build for change detection
-	if err := os.MkdirAll(".build", dirPermission); err != nil {
+	if err := os.MkdirAll(".build", DirPermission); err != nil {
 		return fmt.Errorf("create .build directory: %w", err)
 	}
-	if err := copyFile("docker/Dockerfile", ".build/Dockerfile"); err != nil {
+	if err := CopyFile("docker/Dockerfile", ".build/Dockerfile"); err != nil {
 		return fmt.Errorf("copy Dockerfile to .build: %w", err)
 	}
 
 	return nil
 }
 
-func (dm *DockerManager) checkImageUpToDate(ctx context.Context, logger *slog.Logger) (bool, error) {
+func (dm *Manager) checkImageUpToDate(ctx context.Context, logger *slog.Logger) (bool, error) {
 	containerImageID, err := dm.getContainerImageID(ctx, logger)
 	if err != nil {
 		return false, err
@@ -302,7 +307,7 @@ func (dm *DockerManager) checkImageUpToDate(ctx context.Context, logger *slog.Lo
 	return containerImageID == imageID, nil
 }
 
-func (dm *DockerManager) getContainerImageID(ctx context.Context, logger *slog.Logger) (string, error) {
+func (dm *Manager) getContainerImageID(ctx context.Context, logger *slog.Logger) (string, error) {
 	cmd := exec.CommandContext(ctx, "docker", "inspect", dm.config.Name) //nolint:gosec
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
@@ -324,7 +329,7 @@ func (dm *DockerManager) getContainerImageID(ctx context.Context, logger *slog.L
 	return result[0].Image, nil
 }
 
-func (dm *DockerManager) getImageID(ctx context.Context, logger *slog.Logger) (string, error) {
+func (dm *Manager) getImageID(ctx context.Context, logger *slog.Logger) (string, error) {
 	cmd := exec.CommandContext(ctx, "docker", "inspect", dm.config.Image) //nolint:gosec
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
@@ -346,11 +351,11 @@ func (dm *DockerManager) getImageID(ctx context.Context, logger *slog.Logger) (s
 	return result[0].ID, nil
 }
 
-func (dm *DockerManager) runContainer(ctx context.Context, logger *slog.Logger) error {
+func (dm *Manager) runContainer(ctx context.Context, logger *slog.Logger) error {
 	args := []string{"run", "-d", "--name", dm.config.Name}
 
 	// Add --privileged for Podman on Linux
-	if runtime.GOOS == "linux" && isPodman(ctx, logger) {
+	if runtime.GOOS == "linux" && IsPodman(ctx, logger) {
 		args = append(args, "--privileged")
 	}
 
@@ -366,7 +371,7 @@ func (dm *DockerManager) runContainer(ctx context.Context, logger *slog.Logger) 
 	return nil
 }
 
-func (dm *DockerManager) startContainer(ctx context.Context, logger *slog.Logger) error {
+func (dm *Manager) startContainer(ctx context.Context, logger *slog.Logger) error {
 	cmd := exec.CommandContext(ctx, "docker", "start", dm.config.Name) //nolint:gosec
 	logger.Info("+ " + cmd.String())
 	cmd.Stdout = os.Stdout
@@ -378,15 +383,17 @@ func (dm *DockerManager) startContainer(ctx context.Context, logger *slog.Logger
 	return nil
 }
 
-func copyFile(src, dst string) error {
+// CopyFile copies a file from src to dst.
+func CopyFile(src, dst string) error {
 	data, err := os.ReadFile(src)
 	if err != nil {
 		return err //nolint:wrapcheck
 	}
-	return os.WriteFile(dst, data, filePermission) //nolint:wrapcheck,gosec
+	return os.WriteFile(dst, data, FilePermission) //nolint:wrapcheck,gosec
 }
 
-func redactSecrets(s string, env map[string]string) string {
+// RedactSecrets replaces secret values in a string with <REDACTED>.
+func RedactSecrets(s string, env map[string]string) string {
 	for _, v := range env {
 		if v != "" {
 			s = strings.ReplaceAll(s, v, "<REDACTED>")
@@ -395,7 +402,8 @@ func redactSecrets(s string, env map[string]string) string {
 	return s
 }
 
-func isPodman(ctx context.Context, logger *slog.Logger) bool {
+// IsPodman checks if Docker is actually Podman.
+func IsPodman(ctx context.Context, logger *slog.Logger) bool {
 	cmd := exec.CommandContext(ctx, "docker", "version")
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -13,14 +13,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aquaproj/registry-tool/pkg/docker"
 	genrg "github.com/aquaproj/registry-tool/pkg/generate-registry"
 	"github.com/aquaproj/registry-tool/pkg/initcmd"
 	"github.com/aquaproj/registry-tool/pkg/osexec"
-)
-
-const (
-	dirPermission  os.FileMode = 0o775
-	filePermission os.FileMode = 0o644
 )
 
 // Scaffold is the main entry point for the scaffold command.
@@ -47,7 +43,7 @@ func scaffoldLocal(ctx context.Context, logger *slog.Logger, cfg *Config) error 
 	pkgFile := filepath.Join(pkgDir, "pkg.yaml")
 	rgFile := filepath.Join(pkgDir, "registry.yaml")
 
-	if err := os.MkdirAll(pkgDir, dirPermission); err != nil {
+	if err := os.MkdirAll(pkgDir, docker.DirPermission); err != nil {
 		return fmt.Errorf("create directories: %w", err)
 	}
 
@@ -87,8 +83,8 @@ func scaffoldFull(ctx context.Context, logger *slog.Logger, cfg *Config) error {
 	}
 
 	logger.Info("Starting Linux container")
-	linuxContainer := DefaultLinuxContainer()
-	linuxDM := NewDockerManager(linuxContainer)
+	linuxContainer := docker.DefaultLinuxContainer()
+	linuxDM := docker.NewManager(linuxContainer)
 	if err := linuxDM.EnsureContainer(ctx, logger, cfg.Recreate); err != nil {
 		return fmt.Errorf("failed to ensure Linux container: %w", err)
 	}
@@ -114,15 +110,15 @@ func scaffoldFull(ctx context.Context, logger *slog.Logger, cfg *Config) error {
 	return nil
 }
 
-func runTests(ctx context.Context, logger *slog.Logger, cfg *Config, linuxDM *DockerManager, pkgName string) error {
+func runTests(ctx context.Context, logger *slog.Logger, cfg *Config, linuxDM *docker.Manager, pkgName string) error {
 	logger.Info("Running Linux/Darwin tests")
 	if err := RunLinuxDarwinTests(ctx, logger, linuxDM, pkgName); err != nil {
 		return fmt.Errorf("Linux/Darwin tests failed: %w", err)
 	}
 
 	logger.Info("Starting a container for Windows")
-	windowsContainer := DefaultWindowsContainer()
-	windowsDM := NewDockerManager(windowsContainer)
+	windowsContainer := docker.DefaultWindowsContainer()
+	windowsDM := docker.NewManager(windowsContainer)
 	if err := windowsDM.EnsureContainer(ctx, logger, cfg.Recreate); err != nil {
 		return fmt.Errorf("failed to ensure Windows container: %w", err)
 	}
@@ -136,12 +132,12 @@ func runTests(ctx context.Context, logger *slog.Logger, cfg *Config, linuxDM *Do
 }
 
 // scaffoldInContainer runs aqua gr inside the Docker container.
-func scaffoldInContainer(ctx context.Context, logger *slog.Logger, dm *DockerManager, cfg *Config) error {
+func scaffoldInContainer(ctx context.Context, logger *slog.Logger, dm *docker.Manager, cfg *Config) error {
 	pkgName := cfg.PkgName
 	pkgDir := filepath.Join(append([]string{"pkgs"}, strings.Split(pkgName, "/")...)...)
 
 	// Create local package directory
-	if err := os.MkdirAll(pkgDir, dirPermission); err != nil {
+	if err := os.MkdirAll(pkgDir, docker.DirPermission); err != nil {
 		return fmt.Errorf("create directories: %w", err)
 	}
 
@@ -159,16 +155,16 @@ func scaffoldInContainer(ctx context.Context, logger *slog.Logger, dm *DockerMan
 	}
 
 	// Copy results back from container
-	if err := dm.CopyFrom(ctx, logger, dm.config.WorkingDir+"/pkg.yaml", filepath.Join(pkgDir, "pkg.yaml")); err != nil {
+	if err := dm.CopyFrom(ctx, logger, dm.Config().WorkingDir+"/pkg.yaml", filepath.Join(pkgDir, "pkg.yaml")); err != nil {
 		return fmt.Errorf("copy pkg.yaml from container: %w", err)
 	}
-	if err := dm.CopyTo(ctx, logger, filepath.Join(pkgDir, "registry.yaml"), dm.config.WorkingDir+"/registry.yaml"); err != nil {
+	if err := dm.CopyTo(ctx, logger, filepath.Join(pkgDir, "registry.yaml"), dm.Config().WorkingDir+"/registry.yaml"); err != nil {
 		return fmt.Errorf("copy registry.yaml from container: %w", err)
 	}
 
 	// Copy scaffold config to package directory if provided
 	if cfg.ConfigPath != "" {
-		if err := copyFile(cfg.ConfigPath, filepath.Join(pkgDir, "scaffold.yaml")); err != nil {
+		if err := docker.CopyFile(cfg.ConfigPath, filepath.Join(pkgDir, "scaffold.yaml")); err != nil {
 			return fmt.Errorf("copy scaffold config to pkgs: %w", err)
 		}
 	}
@@ -176,9 +172,9 @@ func scaffoldInContainer(ctx context.Context, logger *slog.Logger, dm *DockerMan
 	return nil
 }
 
-func copyScaffoldConfig(ctx context.Context, logger *slog.Logger, dm *DockerManager, cfg *Config, pkgDir string) error {
+func copyScaffoldConfig(ctx context.Context, logger *slog.Logger, dm *docker.Manager, cfg *Config, pkgDir string) error {
 	if cfg.ConfigPath != "" {
-		if err := dm.CopyTo(ctx, logger, cfg.ConfigPath, dm.config.WorkingDir+"/scaffold.yaml"); err != nil {
+		if err := dm.CopyTo(ctx, logger, cfg.ConfigPath, dm.Config().WorkingDir+"/scaffold.yaml"); err != nil {
 			return fmt.Errorf("copy scaffold config to container: %w", err)
 		}
 		return nil
@@ -187,14 +183,14 @@ func copyScaffoldConfig(ctx context.Context, logger *slog.Logger, dm *DockerMana
 	scaffoldConfig := filepath.Join(pkgDir, "scaffold.yaml")
 	if _, err := os.Stat(scaffoldConfig); err == nil {
 		logger.Info("using scaffold config", "path", scaffoldConfig)
-		if err := dm.CopyTo(ctx, logger, scaffoldConfig, dm.config.WorkingDir+"/scaffold.yaml"); err != nil {
+		if err := dm.CopyTo(ctx, logger, scaffoldConfig, dm.Config().WorkingDir+"/scaffold.yaml"); err != nil {
 			return fmt.Errorf("copy scaffold config to container: %w", err)
 		}
 	}
 	return nil
 }
 
-func runAquaGRInContainer(ctx context.Context, logger *slog.Logger, dm *DockerManager, cfg *Config, pkgDir string) error {
+func runAquaGRInContainer(ctx context.Context, logger *slog.Logger, dm *docker.Manager, cfg *Config, pkgDir string) error {
 	token, err := getGitHubToken(ctx, logger)
 	if err != nil {
 		return fmt.Errorf("get a GitHub access token: %w", err)
@@ -218,11 +214,11 @@ func runAquaGRInContainer(ctx context.Context, logger *slog.Logger, dm *DockerMa
 	grCmd = append(grCmd, cfg.PkgName)
 
 	args := make([]string, 0, 3+2*len(env)+1+len(grCmd))
-	args = append(args, "exec", "-w", containerWorkingDir)
+	args = append(args, "exec", "-w", docker.ContainerWorkingDir)
 	for k, v := range env {
 		args = append(args, "-e", k+"="+v)
 	}
-	args = append(args, dm.config.Name)
+	args = append(args, dm.Config().Name)
 	args = append(args, grCmd...)
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
@@ -230,7 +226,7 @@ func runAquaGRInContainer(ctx context.Context, logger *slog.Logger, dm *DockerMa
 	cmd.Stdout = buf
 	cmd.Stderr = os.Stderr
 	osexec.SetCancel(logger, cmd)
-	logger.Info("+ " + redactSecrets(cmd.String(), env))
+	logger.Info("+ " + docker.RedactSecrets(cmd.String(), env))
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker exec: %w", err)
 	}

--- a/pkg/scaffold/config.go
+++ b/pkg/scaffold/config.go
@@ -27,33 +27,6 @@ type Config struct {
 	ConfigPath string
 }
 
-// ContainerConfig holds Docker container configuration.
-type ContainerConfig struct {
-	Name       string
-	Image      string
-	WorkingDir string
-}
-
-const containerWorkingDir = "/workspace"
-
-// DefaultLinuxContainer returns the default Linux container configuration.
-func DefaultLinuxContainer() ContainerConfig {
-	return ContainerConfig{
-		Name:       "aqua-registry",
-		Image:      "aquaproj/aqua-registry",
-		WorkingDir: containerWorkingDir,
-	}
-}
-
-// DefaultWindowsContainer returns the default Windows container configuration.
-func DefaultWindowsContainer() ContainerConfig {
-	return ContainerConfig{
-		Name:       "aqua-registry-windows",
-		Image:      "aquaproj/aqua-registry",
-		WorkingDir: containerWorkingDir,
-	}
-}
-
 // Platform represents a target platform for testing.
 type Platform struct {
 	OS   string

--- a/pkg/scaffold/test.go
+++ b/pkg/scaffold/test.go
@@ -5,17 +5,19 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+
+	"github.com/aquaproj/registry-tool/pkg/docker"
 )
 
 // RunTests runs aqua install tests on the specified platforms.
-func RunTests(ctx context.Context, logger *slog.Logger, dm *DockerManager, pkgName string, platforms []Platform) error {
+func RunTests(ctx context.Context, logger *slog.Logger, dm *docker.Manager, pkgName string, platforms []Platform) error {
 	pkgDir := filepath.Join("pkgs", pkgName)
 
 	// Copy package files to container
-	if err := dm.CopyTo(ctx, logger, filepath.Join(pkgDir, "pkg.yaml"), dm.config.WorkingDir+"/pkg.yaml"); err != nil {
+	if err := dm.CopyTo(ctx, logger, filepath.Join(pkgDir, "pkg.yaml"), dm.Config().WorkingDir+"/pkg.yaml"); err != nil {
 		return fmt.Errorf("copy pkg.yaml to container: %w", err)
 	}
-	if err := dm.CopyTo(ctx, logger, filepath.Join(pkgDir, "registry.yaml"), dm.config.WorkingDir+"/registry.yaml"); err != nil {
+	if err := dm.CopyTo(ctx, logger, filepath.Join(pkgDir, "registry.yaml"), dm.Config().WorkingDir+"/registry.yaml"); err != nil {
 		return fmt.Errorf("copy registry.yaml to container: %w", err)
 	}
 
@@ -41,11 +43,11 @@ func RunTests(ctx context.Context, logger *slog.Logger, dm *DockerManager, pkgNa
 }
 
 // RunLinuxDarwinTests runs tests for Linux and Darwin platforms.
-func RunLinuxDarwinTests(ctx context.Context, logger *slog.Logger, dm *DockerManager, pkgName string) error {
+func RunLinuxDarwinTests(ctx context.Context, logger *slog.Logger, dm *docker.Manager, pkgName string) error {
 	return RunTests(ctx, logger, dm, pkgName, LinuxDarwinPlatforms())
 }
 
 // RunWindowsTests runs tests for Windows platforms.
-func RunWindowsTests(ctx context.Context, logger *slog.Logger, dm *DockerManager, pkgName string) error {
+func RunWindowsTests(ctx context.Context, logger *slog.Logger, dm *docker.Manager, pkgName string) error {
 	return RunTests(ctx, logger, dm, pkgName, WindowsPlatforms())
 }

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -1,0 +1,22 @@
+package start
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/aquaproj/registry-tool/pkg/docker"
+)
+
+// Start starts Docker containers for the Linux and Windows environments.
+func Start(ctx context.Context, logger *slog.Logger, recreate bool) error {
+	linuxDM := docker.NewManager(docker.DefaultLinuxContainer())
+	if err := linuxDM.EnsureContainer(ctx, logger, recreate); err != nil {
+		return fmt.Errorf("ensure Linux container: %w", err)
+	}
+	windowsDM := docker.NewManager(docker.DefaultWindowsContainer())
+	if err := windowsDM.EnsureContainer(ctx, logger, recreate); err != nil {
+		return fmt.Errorf("ensure Windows container: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Extract Docker management code (`DockerManager`, `ContainerConfig`, etc.) from `pkg/scaffold/` into a new `pkg/docker/` package with renamed types (`Manager`, `Config`) to avoid stutter
- Add `pkg/start/` package with a `Start` function that ensures both Linux and Windows containers
- Add `start` CLI command with `--recreate` / `-r` flag to start Docker containers
- Update `pkg/scaffold/` to import from `pkg/docker/`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -race -covermode=atomic` passes
- [x] `golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)