### PR TITLE
feat: add test command to test packages in Docker containers

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aquaproj/registry-tool/pkg/cli/resolveconflict"
 	"github.com/aquaproj/registry-tool/pkg/cli/scaffold"
 	startcmd "github.com/aquaproj/registry-tool/pkg/cli/start"
+	testcmd "github.com/aquaproj/registry-tool/pkg/cli/test"
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
 	"github.com/urfave/cli/v3"
@@ -43,6 +44,7 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 			mv.Command(),
 			resolveconflict.Command(logger.Logger),
 			startcmd.Command(logger.Logger),
+			testcmd.Command(logger.Logger),
 		},
 	}).Run(ctx, env.Args)
 }

--- a/pkg/cli/test/command.go
+++ b/pkg/cli/test/command.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	"context"
+	"log/slog"
+
+	testpkg "github.com/aquaproj/registry-tool/pkg/test"
+	"github.com/urfave/cli/v3"
+)
+
+func Command(logger *slog.Logger) *cli.Command {
+	var recreate bool
+	return &cli.Command{
+		Name:      "test",
+		Aliases:   []string{"t"},
+		Usage:     "Test a package in Docker containers",
+		UsageText: "aqua-registry test [-r] [<package name>]",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "recreate",
+				Aliases:     []string{"r"},
+				Usage:       "Recreate the containers",
+				Destination: &recreate,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return testpkg.Test(ctx, logger, &testpkg.Config{
+				PkgName:  cmd.Args().First(),
+				Recreate: recreate,
+			})
+		},
+	}
+}

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -1,0 +1,76 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/aquaproj/registry-tool/pkg/docker"
+	genrg "github.com/aquaproj/registry-tool/pkg/generate-registry"
+	"github.com/aquaproj/registry-tool/pkg/scaffold"
+)
+
+// Config holds configuration for the test command.
+type Config struct {
+	PkgName  string
+	Recreate bool
+}
+
+// Test tests a package in Docker containers across all platforms.
+func Test(ctx context.Context, logger *slog.Logger, cfg *Config) error {
+	pkgName, err := resolvePkgName(ctx, logger, cfg.PkgName)
+	if err != nil {
+		return err
+	}
+
+	// Ensure Linux container
+	linuxDM := docker.NewManager(docker.DefaultLinuxContainer())
+	if err := linuxDM.EnsureContainer(ctx, logger, cfg.Recreate); err != nil {
+		return fmt.Errorf("ensure Linux container: %w", err)
+	}
+
+	// Run Linux/Darwin tests
+	logger.Info("Running Linux/Darwin tests")
+	if err := scaffold.RunLinuxDarwinTests(ctx, logger, linuxDM, pkgName); err != nil {
+		return fmt.Errorf("Linux/Darwin tests failed: %w", err)
+	}
+
+	// Ensure Windows container
+	windowsDM := docker.NewManager(docker.DefaultWindowsContainer())
+	if err := windowsDM.EnsureContainer(ctx, logger, cfg.Recreate); err != nil {
+		return fmt.Errorf("ensure Windows container: %w", err)
+	}
+
+	// Run Windows tests
+	logger.Info("Running Windows tests")
+	if err := scaffold.RunWindowsTests(ctx, logger, windowsDM, pkgName); err != nil {
+		return fmt.Errorf("windows tests failed: %w", err)
+	}
+
+	// Update registry.yaml
+	logger.Info("Updating registry.yaml")
+	if err := genrg.GenerateRegistry(); err != nil {
+		return fmt.Errorf("update registry.yaml: %w", err)
+	}
+
+	return nil
+}
+
+func resolvePkgName(ctx context.Context, logger *slog.Logger, pkgName string) (string, error) {
+	if pkgName != "" {
+		return strings.TrimPrefix(pkgName, "https://github.com/"), nil
+	}
+
+	branch, err := scaffold.GetCurrentBranch(ctx, logger)
+	if err != nil {
+		return "", fmt.Errorf("get current branch: %w", err)
+	}
+
+	if !strings.HasPrefix(branch, "feat/") {
+		return "", errors.New("current branch must be feat/<package name> or you must give a package name")
+	}
+
+	return strings.TrimPrefix(branch, "feat/"), nil
+}


### PR DESCRIPTION
## Summary
- Add `test` (`t`) command that tests a package in Docker containers across all platforms (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64)
- Resolves package name from CLI argument or current `feat/<pkg>` branch
- Supports `--recreate` / `-r` flag to recreate containers before testing

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race -covermode=atomic`
- [x] `golangci-lint run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)