### PR TITLE
feat: add stop command to stop Docker containers

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aquaproj/registry-tool/pkg/cli/resolveconflict"
 	"github.com/aquaproj/registry-tool/pkg/cli/scaffold"
 	startcmd "github.com/aquaproj/registry-tool/pkg/cli/start"
+	stopcmd "github.com/aquaproj/registry-tool/pkg/cli/stop"
 	testcmd "github.com/aquaproj/registry-tool/pkg/cli/test"
 	"github.com/suzuki-shunsuke/slog-util/slogutil"
 	"github.com/suzuki-shunsuke/urfave-cli-v3-util/urfave"
@@ -44,6 +45,7 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 			mv.Command(),
 			resolveconflict.Command(logger.Logger),
 			startcmd.Command(logger.Logger),
+			stopcmd.Command(logger.Logger),
 			testcmd.Command(logger.Logger),
 		},
 	}).Run(ctx, env.Args)

--- a/pkg/cli/stop/command.go
+++ b/pkg/cli/stop/command.go
@@ -1,0 +1,20 @@
+package stop
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aquaproj/registry-tool/pkg/stop"
+	"github.com/urfave/cli/v3"
+)
+
+func Command(logger *slog.Logger) *cli.Command {
+	return &cli.Command{
+		Name:      "stop",
+		Usage:     "Stop Docker containers",
+		UsageText: "aqua-registry stop",
+		Action: func(ctx context.Context, _ *cli.Command) error {
+			return stop.Stop(ctx, logger)
+		},
+	}
+}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -138,6 +138,27 @@ func (dm *Manager) RemoveContainer(ctx context.Context, logger *slog.Logger) err
 	return nil
 }
 
+// StopContainer stops the container if it is running.
+func (dm *Manager) StopContainer(ctx context.Context, logger *slog.Logger) error {
+	running, err := dm.ContainerRunning(ctx, logger)
+	if err != nil {
+		return err
+	}
+	if !running {
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, "docker", "stop", "-t", "1", dm.config.Name) //nolint:gosec
+	logger.Info("+ " + cmd.String())
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	osexec.SetCancel(logger, cmd)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker stop: %w", err)
+	}
+	return nil
+}
+
 // Exec executes a command in the container.
 func (dm *Manager) Exec(ctx context.Context, logger *slog.Logger, env map[string]string, command ...string) error {
 	args := []string{"exec"}

--- a/pkg/stop/stop.go
+++ b/pkg/stop/stop.go
@@ -1,0 +1,22 @@
+package stop
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/aquaproj/registry-tool/pkg/docker"
+)
+
+// Stop stops Docker containers for the Linux and Windows environments.
+func Stop(ctx context.Context, logger *slog.Logger) error {
+	linuxDM := docker.NewManager(docker.DefaultLinuxContainer())
+	if err := linuxDM.StopContainer(ctx, logger); err != nil {
+		return fmt.Errorf("stop Linux container: %w", err)
+	}
+	windowsDM := docker.NewManager(docker.DefaultWindowsContainer())
+	if err := windowsDM.StopContainer(ctx, logger); err != nil {
+		return fmt.Errorf("stop Windows container: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `StopContainer` method to `docker.Manager` that stops a running container without removing it
- Add `stop` command that stops both Linux and Windows Docker containers
- Mirrors the existing `start` command pattern

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -race -covermode=atomic` passes
- [x] `golangci-lint run` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)