### PR TITLE
feat: add remove command to remove Docker containers

### DIFF
--- a/pkg/cli/remove/command.go
+++ b/pkg/cli/remove/command.go
@@ -1,0 +1,21 @@
+package remove
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aquaproj/registry-tool/pkg/remove"
+	"github.com/urfave/cli/v3"
+)
+
+func Command(logger *slog.Logger) *cli.Command {
+	return &cli.Command{
+		Name:      "remove",
+		Aliases:   []string{"rm"},
+		Usage:     "Remove Docker containers",
+		UsageText: "aqua-registry remove",
+		Action: func(ctx context.Context, _ *cli.Command) error {
+			return remove.Remove(ctx, logger)
+		},
+	}
+}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aquaproj/registry-tool/pkg/cli/initcmd"
 	"github.com/aquaproj/registry-tool/pkg/cli/mv"
 	"github.com/aquaproj/registry-tool/pkg/cli/patchchecksum"
+	removecmd "github.com/aquaproj/registry-tool/pkg/cli/remove"
 	"github.com/aquaproj/registry-tool/pkg/cli/resolveconflict"
 	"github.com/aquaproj/registry-tool/pkg/cli/scaffold"
 	startcmd "github.com/aquaproj/registry-tool/pkg/cli/start"
@@ -43,6 +44,7 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 			patchchecksum.Command(logger.Logger),
 			checkrepo.Command(),
 			mv.Command(),
+			removecmd.Command(logger.Logger),
 			resolveconflict.Command(logger.Logger),
 			startcmd.Command(logger.Logger),
 			stopcmd.Command(logger.Logger),

--- a/pkg/remove/remove.go
+++ b/pkg/remove/remove.go
@@ -1,0 +1,22 @@
+package remove
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/aquaproj/registry-tool/pkg/docker"
+)
+
+// Remove removes Docker containers for the Linux and Windows environments.
+func Remove(ctx context.Context, logger *slog.Logger) error {
+	linuxDM := docker.NewManager(docker.DefaultLinuxContainer())
+	if err := linuxDM.RemoveContainer(ctx, logger); err != nil {
+		return fmt.Errorf("remove Linux container: %w", err)
+	}
+	windowsDM := docker.NewManager(docker.DefaultWindowsContainer())
+	if err := windowsDM.RemoveContainer(ctx, logger); err != nil {
+		return fmt.Errorf("remove Windows container: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `remove` (alias `rm`) command that removes Docker containers for both Linux and Windows environments
- Mirrors the existing `stop` command pattern, calling `RemoveContainer` instead of `StopContainer`
- Registers the new command in the CLI runner

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -race -covermode=atomic` passes
- [x] `golangci-lint run` passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)