### PR TITLE
feat: add connect command to attach interactive shell to Docker containers

### DIFF
--- a/pkg/cli/connect/command.go
+++ b/pkg/cli/connect/command.go
@@ -1,0 +1,21 @@
+package connect
+
+import (
+	"context"
+	"log/slog"
+
+	connectpkg "github.com/aquaproj/registry-tool/pkg/connect"
+	"github.com/urfave/cli/v3"
+)
+
+func Command(logger *slog.Logger) *cli.Command {
+	return &cli.Command{
+		Name:      "connect",
+		Aliases:   []string{"con"},
+		Usage:     "Connect to a Docker container with an interactive shell",
+		UsageText: "aqua-registry connect [<os>] [<arch>]",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return connectpkg.Connect(ctx, logger, cmd.Args().Get(0), cmd.Args().Get(1))
+		},
+	}
+}

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aquaproj/registry-tool/pkg/cli/checkrepo"
+	connectcmd "github.com/aquaproj/registry-tool/pkg/cli/connect"
 	"github.com/aquaproj/registry-tool/pkg/cli/createprnewpkg"
 	"github.com/aquaproj/registry-tool/pkg/cli/gengr"
 	"github.com/aquaproj/registry-tool/pkg/cli/gflag"
@@ -45,6 +46,7 @@ func Run(ctx context.Context, logger *slogutil.Logger, env *urfave.Env) error {
 			patchchecksum.Command(logger.Logger),
 			checkrepo.Command(),
 			mv.Command(),
+			connectcmd.Command(logger.Logger),
 			removecmd.Command(logger.Logger),
 			removepackagecmd.Command(logger.Logger),
 			resolveconflict.Command(logger.Logger),

--- a/pkg/connect/connect.go
+++ b/pkg/connect/connect.go
@@ -1,0 +1,43 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime"
+
+	"github.com/aquaproj/registry-tool/pkg/docker"
+)
+
+func Connect(ctx context.Context, logger *slog.Logger, osName, arch string) error {
+	if osName == "" {
+		osName = "linux"
+	}
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
+
+	var config docker.Config
+	if osName == "windows" {
+		config = docker.DefaultWindowsContainer()
+	} else {
+		config = docker.DefaultLinuxContainer()
+	}
+
+	dm := docker.NewManager(config)
+
+	env := map[string]string{
+		"AQUA_GOOS":   osName,
+		"AQUA_GOARCH": arch,
+	}
+
+	// Run aqua i -l as a workaround
+	if err := dm.Exec(ctx, logger, env, "aqua", "i", "-l"); err != nil {
+		return fmt.Errorf("run aqua i -l: %w", err)
+	}
+
+	if err := dm.ExecInteractive(ctx, logger, env, "bash"); err != nil {
+		return fmt.Errorf("run interactive bash: %w", err)
+	}
+	return nil
+}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -182,6 +182,30 @@ func (dm *Manager) Exec(ctx context.Context, logger *slog.Logger, env map[string
 	return nil
 }
 
+// ExecInteractive executes an interactive command in the container with stdin attached.
+func (dm *Manager) ExecInteractive(ctx context.Context, logger *slog.Logger, env map[string]string, command ...string) error {
+	args := []string{"exec", "-i", "-t"}
+	if dm.config.WorkingDir != "" {
+		args = append(args, "-w", dm.config.WorkingDir)
+	}
+	for k, v := range env {
+		args = append(args, "-e", k+"="+v)
+	}
+	args = append(args, dm.config.Name)
+	args = append(args, command...)
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	logger.Info("+ " + RedactSecrets(cmd.String(), env))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	osexec.SetCancel(logger, cmd)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker exec: %w", err)
+	}
+	return nil
+}
+
 // ExecBash executes a bash command in the container.
 func (dm *Manager) ExecBash(ctx context.Context, logger *slog.Logger, bashCmd string) error {
 	return dm.Exec(ctx, logger, nil, "bash", "-c", bashCmd)


### PR DESCRIPTION
## Summary
- Add `connect` command (alias `con`) that attaches an interactive bash shell to a Docker container with `AQUA_GOOS` and `AQUA_GOARCH` set
- Add `ExecInteractive` method to `docker.Manager` for interactive `docker exec` with `-ti` flags and stdin attached
- Accepts optional positional args: `os` (default `linux`) and `arch` (default from `runtime.GOARCH`)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race -covermode=atomic`
- [x] `golangci-lint run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)