### PR TITLE
feat: test packages with key: libc variants on Alpine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/aquaproj/aqua/v2 v2.57.1
 	github.com/goccy/go-yaml v1.19.2
+	github.com/google/go-cmp v0.7.0
 	github.com/spf13/afero v1.15.0
 	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.2.2
 	github.com/suzuki-shunsuke/go-yamledit v0.0.1

--- a/pkg/docker/config.go
+++ b/pkg/docker/config.go
@@ -7,6 +7,9 @@ type Config struct {
 	Name       string
 	Image      string
 	WorkingDir string
+	// Dockerfile is the file name under docker/ used to build the image.
+	// If empty, "Dockerfile" is used.
+	Dockerfile string
 }
 
 const (
@@ -33,5 +36,17 @@ func DefaultWindowsContainer() Config {
 		Name:       "aqua-registry-windows",
 		Image:      "aquaproj/aqua-registry",
 		WorkingDir: ContainerWorkingDir,
+	}
+}
+
+// DefaultAlpineContainer returns the default Alpine (musl) Linux container configuration.
+// It is used when registry.yaml contains packages with `key: libc` variants
+// to verify both musl and gnu libc paths.
+func DefaultAlpineContainer() Config {
+	return Config{
+		Name:       "aqua-registry-alpine",
+		Image:      "aquaproj/aqua-registry-alpine",
+		WorkingDir: ContainerWorkingDir,
+		Dockerfile: "Dockerfile-alpine",
 	}
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -294,20 +295,29 @@ func (dm *Manager) imageExists(ctx context.Context, logger *slog.Logger) bool {
 	return cmd.Run() == nil
 }
 
+func (dm *Manager) dockerfileName() string {
+	if dm.config.Dockerfile == "" {
+		return "Dockerfile"
+	}
+	return dm.config.Dockerfile
+}
+
 func (dm *Manager) dockerfileNotChanged() (bool, error) {
-	// Check if .build/Dockerfile exists
-	if _, err := os.Stat(".build/Dockerfile"); os.IsNotExist(err) {
+	name := dm.dockerfileName()
+	srcPath := filepath.Join("docker", name)
+	cachePath := filepath.Join(".build", name)
+
+	if _, err := os.Stat(cachePath); os.IsNotExist(err) {
 		return false, nil
 	}
 
-	// Compare docker/Dockerfile with .build/Dockerfile
-	b1, err := os.ReadFile("docker/Dockerfile")
+	b1, err := os.ReadFile(srcPath)
 	if err != nil {
-		return false, fmt.Errorf("read docker/Dockerfile: %w", err)
+		return false, fmt.Errorf("read %s: %w", srcPath, err)
 	}
-	b2, err := os.ReadFile(".build/Dockerfile")
+	b2, err := os.ReadFile(cachePath)
 	if err != nil {
-		return false, fmt.Errorf("read .build/Dockerfile: %w", err)
+		return false, fmt.Errorf("read %s: %w", cachePath, err)
 	}
 	return string(b1) == string(b2), nil
 }
@@ -318,8 +328,10 @@ func (dm *Manager) buildImage(ctx context.Context, logger *slog.Logger) error {
 		return fmt.Errorf("copy aqua-policy.yaml: %w", err)
 	}
 
-	// Build Docker image
-	cmd := exec.CommandContext(ctx, "docker", "build", "-t", dm.config.Image, "docker") //nolint:gosec
+	name := dm.dockerfileName()
+	src := filepath.Join("docker", name)
+
+	cmd := exec.CommandContext(ctx, "docker", "build", "-t", dm.config.Image, "-f", src, "docker") //nolint:gosec
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	osexec.SetCancel(logger, cmd)
@@ -327,12 +339,11 @@ func (dm *Manager) buildImage(ctx context.Context, logger *slog.Logger) error {
 		return fmt.Errorf("docker build: %w", err)
 	}
 
-	// Save Dockerfile to .build for change detection
 	if err := os.MkdirAll(".build", DirPermission); err != nil {
 		return fmt.Errorf("create .build directory: %w", err)
 	}
-	if err := CopyFile("docker/Dockerfile", ".build/Dockerfile"); err != nil {
-		return fmt.Errorf("copy Dockerfile to .build: %w", err)
+	if err := CopyFile(src, filepath.Join(".build", name)); err != nil {
+		return fmt.Errorf("copy %s to .build: %w", name, err)
 	}
 
 	return nil

--- a/pkg/libc/libc.go
+++ b/pkg/libc/libc.go
@@ -1,0 +1,74 @@
+// Package libc detects whether a registry.yaml contains packages whose
+// variants distinguish musl and gnu libc (i.e. variants with `key: libc`).
+package libc
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+const variantKeyLibc = "libc"
+
+type variant struct {
+	Key string `yaml:"key"`
+}
+
+type override struct {
+	Variants []variant `yaml:"variants"`
+}
+
+type versionOverride struct {
+	Overrides []override `yaml:"overrides"`
+}
+
+type pkg struct {
+	Overrides        []override        `yaml:"overrides"`
+	VersionOverrides []versionOverride `yaml:"version_overrides"`
+}
+
+type root struct {
+	Packages []pkg `yaml:"packages"`
+}
+
+// HasVariant reports whether the registry.yaml at path contains any package
+// with a variant whose key is "libc". It returns (false, nil) when the file
+// does not exist.
+func HasVariant(path string) (bool, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var r root
+	if err := yaml.Unmarshal(b, &r); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, p := range r.Packages {
+		if anyOverrideHasLibc(p.Overrides) {
+			return true, nil
+		}
+		for _, vo := range p.VersionOverrides {
+			if anyOverrideHasLibc(vo.Overrides) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func anyOverrideHasLibc(ovs []override) bool {
+	for _, ov := range ovs {
+		for _, v := range ov.Variants {
+			if v.Key == variantKeyLibc {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/libc/libc_test.go
+++ b/pkg/libc/libc_test.go
@@ -1,0 +1,117 @@
+package libc_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aquaproj/registry-tool/pkg/libc"
+	"github.com/google/go-cmp/cmp"
+)
+
+type hasVariantCase struct {
+	name    string
+	yaml    string
+	want    bool
+	wantErr bool
+}
+
+var hasVariantCases = []hasVariantCase{ //nolint:gochecknoglobals
+	{
+		name: "key libc inside overrides variants",
+		yaml: `packages:
+  - type: github_release
+    repo_owner: foo
+    repo_name: bar
+    overrides:
+      - goos: linux
+        variants:
+          - key: libc
+            value: musl
+`,
+		want: true,
+	},
+	{
+		name: "key libc inside version_overrides overrides variants",
+		yaml: `packages:
+  - type: github_release
+    repo_owner: foo
+    repo_name: bar
+    version_overrides:
+      - version_constraint: "true"
+        overrides:
+          - goos: linux
+            variants:
+              - key: libc
+                value: musl
+`,
+		want: true,
+	},
+	{
+		name: "variants without libc key",
+		yaml: `packages:
+  - type: github_release
+    repo_owner: foo
+    repo_name: bar
+    overrides:
+      - goos: linux
+        variants:
+          - key: glibc
+            value: x
+`,
+	},
+	{
+		name: "no variants at all",
+		yaml: `packages:
+  - type: github_release
+    repo_owner: foo
+    repo_name: bar
+`,
+	},
+	{
+		name: "empty packages",
+		yaml: "packages: []\n",
+	},
+	{
+		name:    "invalid yaml",
+		yaml:    "packages: [not a list\n",
+		wantErr: true,
+	},
+}
+
+func TestHasVariant(t *testing.T) {
+	t.Parallel()
+	for _, tt := range hasVariantCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "registry.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := libc.HasVariant(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("HasVariant(-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHasVariant_FileNotExist(t *testing.T) {
+	t.Parallel()
+	got, err := libc.HasVariant(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Errorf("want false, got true")
+	}
+}

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -17,6 +17,7 @@ import (
 	genrg "github.com/aquaproj/registry-tool/pkg/generate-registry"
 	"github.com/aquaproj/registry-tool/pkg/github"
 	"github.com/aquaproj/registry-tool/pkg/initcmd"
+	"github.com/aquaproj/registry-tool/pkg/libc"
 	"github.com/aquaproj/registry-tool/pkg/osexec"
 )
 
@@ -122,6 +123,10 @@ func runTests(ctx context.Context, logger *slog.Logger, cfg *Config, linuxDM *do
 		return fmt.Errorf("Linux/Darwin tests failed: %w", err)
 	}
 
+	if err := runAlpineTestsIfNeeded(ctx, logger, cfg.Recreate, pkgName, githubToken); err != nil {
+		return err
+	}
+
 	logger.Info("Starting a container for Windows")
 	windowsContainer := docker.DefaultWindowsContainer()
 	windowsDM := docker.NewManager(windowsContainer)
@@ -134,6 +139,28 @@ func runTests(ctx context.Context, logger *slog.Logger, cfg *Config, linuxDM *do
 		return fmt.Errorf("windows tests failed: %w", err)
 	}
 
+	return nil
+}
+
+// runAlpineTestsIfNeeded ensures and runs Linux tests on the Alpine container
+// when pkgs/<pkgName>/registry.yaml has any variant with `key: libc`.
+func runAlpineTestsIfNeeded(ctx context.Context, logger *slog.Logger, recreate bool, pkgName, githubToken string) error {
+	rgPath := filepath.Join("pkgs", pkgName, "registry.yaml")
+	hasLibc, err := libc.HasVariant(rgPath)
+	if err != nil {
+		return fmt.Errorf("check libc variant: %w", err)
+	}
+	if !hasLibc {
+		return nil
+	}
+	logger.Info("key: libc detected, running tests on Alpine")
+	alpineDM := docker.NewManager(docker.DefaultAlpineContainer())
+	if err := alpineDM.EnsureContainer(ctx, logger, recreate); err != nil {
+		return fmt.Errorf("ensure Alpine container: %w", err)
+	}
+	if err := RunLinuxTests(ctx, logger, alpineDM, pkgName, githubToken); err != nil {
+		return fmt.Errorf("alpine Linux tests failed: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/scaffold/config.go
+++ b/pkg/scaffold/config.go
@@ -34,6 +34,15 @@ func LinuxDarwinPlatforms() []Platform {
 	}
 }
 
+// LinuxPlatforms returns the Linux platforms for testing.
+// Used for the Alpine (musl) container path where libc differentiation matters.
+func LinuxPlatforms() []Platform {
+	return []Platform{
+		{OS: "linux", Arch: "amd64"},
+		{OS: "linux", Arch: "arm64"},
+	}
+}
+
 // WindowsPlatforms returns the Windows platforms for testing.
 func WindowsPlatforms() []Platform {
 	return []Platform{

--- a/pkg/scaffold/test.go
+++ b/pkg/scaffold/test.go
@@ -48,6 +48,12 @@ func RunLinuxDarwinTests(ctx context.Context, logger *slog.Logger, dm *docker.Ma
 	return RunTests(ctx, logger, dm, pkgName, githubToken, LinuxDarwinPlatforms())
 }
 
+// RunLinuxTests runs tests for Linux platforms only.
+// Intended for the Alpine (musl) container so libc-specific assets are exercised.
+func RunLinuxTests(ctx context.Context, logger *slog.Logger, dm *docker.Manager, pkgName, githubToken string) error {
+	return RunTests(ctx, logger, dm, pkgName, githubToken, LinuxPlatforms())
+}
+
 // RunWindowsTests runs tests for Windows platforms.
 func RunWindowsTests(ctx context.Context, logger *slog.Logger, dm *docker.Manager, pkgName, githubToken string) error {
 	return RunTests(ctx, logger, dm, pkgName, githubToken, WindowsPlatforms())

--- a/pkg/start/start.go
+++ b/pkg/start/start.go
@@ -6,9 +6,12 @@ import (
 	"log/slog"
 
 	"github.com/aquaproj/registry-tool/pkg/docker"
+	"github.com/aquaproj/registry-tool/pkg/libc"
 )
 
 // Start starts Docker containers for the Linux and Windows environments.
+// When the aggregated registry.yaml contains any variant with `key: libc`,
+// the Alpine (musl) container is also started for libc-aware testing.
 func Start(ctx context.Context, logger *slog.Logger, recreate bool) error {
 	linuxDM := docker.NewManager(docker.DefaultLinuxContainer())
 	if err := linuxDM.EnsureContainer(ctx, logger, recreate); err != nil {
@@ -17,6 +20,17 @@ func Start(ctx context.Context, logger *slog.Logger, recreate bool) error {
 	windowsDM := docker.NewManager(docker.DefaultWindowsContainer())
 	if err := windowsDM.EnsureContainer(ctx, logger, recreate); err != nil {
 		return fmt.Errorf("ensure Windows container: %w", err)
+	}
+
+	hasLibc, err := libc.HasVariant("registry.yaml")
+	if err != nil {
+		return fmt.Errorf("check libc variant: %w", err)
+	}
+	if hasLibc {
+		alpineDM := docker.NewManager(docker.DefaultAlpineContainer())
+		if err := alpineDM.EnsureContainer(ctx, logger, recreate); err != nil {
+			return fmt.Errorf("ensure Alpine container: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/stop/stop.go
+++ b/pkg/stop/stop.go
@@ -8,7 +8,9 @@ import (
 	"github.com/aquaproj/registry-tool/pkg/docker"
 )
 
-// Stop stops Docker containers for the Linux and Windows environments.
+// Stop stops Docker containers for the Linux, Windows and Alpine environments.
+// StopContainer is a no-op when the container is not running, so the Alpine
+// container is stopped unconditionally to clean up regardless of variant state.
 func Stop(ctx context.Context, logger *slog.Logger) error {
 	linuxDM := docker.NewManager(docker.DefaultLinuxContainer())
 	if err := linuxDM.StopContainer(ctx, logger); err != nil {
@@ -17,6 +19,10 @@ func Stop(ctx context.Context, logger *slog.Logger) error {
 	windowsDM := docker.NewManager(docker.DefaultWindowsContainer())
 	if err := windowsDM.StopContainer(ctx, logger); err != nil {
 		return fmt.Errorf("stop Windows container: %w", err)
+	}
+	alpineDM := docker.NewManager(docker.DefaultAlpineContainer())
+	if err := alpineDM.StopContainer(ctx, logger); err != nil {
+		return fmt.Errorf("stop Alpine container: %w", err)
 	}
 	return nil
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 
 	"github.com/aquaproj/registry-tool/pkg/docker"
 	genrg "github.com/aquaproj/registry-tool/pkg/generate-registry"
 	"github.com/aquaproj/registry-tool/pkg/github"
+	"github.com/aquaproj/registry-tool/pkg/libc"
 	"github.com/aquaproj/registry-tool/pkg/naming"
 	"github.com/aquaproj/registry-tool/pkg/scaffold"
 )
@@ -42,6 +44,10 @@ func Test(ctx context.Context, logger *slog.Logger, cfg *Config) error {
 		return fmt.Errorf("Linux/Darwin tests failed: %w", err)
 	}
 
+	if err := runAlpineTestsIfNeeded(ctx, logger, cfg.Recreate, pkgName, githubToken); err != nil {
+		return err
+	}
+
 	// Ensure Windows container
 	windowsDM := docker.NewManager(docker.DefaultWindowsContainer())
 	if err := windowsDM.EnsureContainer(ctx, logger, cfg.Recreate); err != nil {
@@ -60,5 +66,26 @@ func Test(ctx context.Context, logger *slog.Logger, cfg *Config) error {
 		return fmt.Errorf("update registry.yaml: %w", err)
 	}
 
+	return nil
+}
+
+// runAlpineTestsIfNeeded runs Linux tests on the Alpine container when
+// pkgs/<pkgName>/registry.yaml has any variant with `key: libc`.
+func runAlpineTestsIfNeeded(ctx context.Context, logger *slog.Logger, recreate bool, pkgName, githubToken string) error {
+	hasLibc, err := libc.HasVariant(filepath.Join("pkgs", pkgName, "registry.yaml"))
+	if err != nil {
+		return fmt.Errorf("check libc variant: %w", err)
+	}
+	if !hasLibc {
+		return nil
+	}
+	logger.Info("key: libc detected, running tests on Alpine")
+	alpineDM := docker.NewManager(docker.DefaultAlpineContainer())
+	if err := alpineDM.EnsureContainer(ctx, logger, recreate); err != nil {
+		return fmt.Errorf("ensure Alpine container: %w", err)
+	}
+	if err := scaffold.RunLinuxTests(ctx, logger, alpineDM, pkgName, githubToken); err != nil {
+		return fmt.Errorf("alpine Linux tests failed: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary

When `registry.yaml` declares a variant with `key: libc` (introduced in [aquaproj/aqua#4514](https://github.com/aquaproj/aqua/issues/4514)), the registry-tool now runs an additional test pass inside an **Alpine (musl)** container after the existing Debian (gnu) pass, so both libc paths are exercised.

The Alpine container builds from `docker/Dockerfile-alpine` (already present in this repo's working tree) and is wired into `argd s` (scaffold), `argd t` (test), `argd start` and `argd stop`. Packages without a libc variant are unaffected — there is no regression for the existing debian → windows flow.

## Changes by area

### `pkg/docker`
- `Config` gains an optional `Dockerfile` field. When empty it defaults to `"Dockerfile"`, preserving the current Debian behavior for `DefaultLinuxContainer` / `DefaultWindowsContainer`.
- `DefaultAlpineContainer()` returns `{Name: aqua-registry-alpine, Image: aquaproj/aqua-registry-alpine, Dockerfile: Dockerfile-alpine}`.
- `buildImage` now passes `-f docker/<name>` and caches `.build/<name>`. `dockerfileNotChanged` compares `docker/<name>` against `.build/<name>` per-Dockerfile, using `filepath.Join` for the paths. Each container therefore tracks its own image freshness independently.

### `pkg/libc` (new)
- `HasVariant(path string) (bool, error)` parses a `registry.yaml` with a minimal local YAML struct (aqua/v2 v2.57.1 does not yet expose a `Variants` type) and returns `true` when any `packages[].overrides[].variants[].key == "libc"` — including the equivalent path under `version_overrides[].overrides[]`.
- Returns `(false, nil)` when the file does not exist, so callers do not need to pre-check.
- Test coverage 95% with table-driven cases for: top-level overrides, nested version_overrides, non-libc keys, no variants/overrides, empty packages, invalid YAML, missing file.

### `pkg/scaffold`
- `LinuxPlatforms()` returns just `linux/amd64` and `linux/arm64`. Darwin/Windows are libc-agnostic, so the Alpine pass deliberately skips them to avoid doubling test time.
- `RunLinuxTests()` is a thin wrapper that runs `RunTests` against `LinuxPlatforms()`.
- `runTests()` in `pkg/scaffold/api.go` was extracted into a helper `runAlpineTestsIfNeeded` that, after Linux/Darwin tests on Debian, checks `pkgs/<pkgName>/registry.yaml` and ensures + runs the Alpine pass if a libc variant is found, before continuing to Windows tests.

### `pkg/test`
- Mirrors the scaffold flow: Debian Linux/Darwin → (if libc) Alpine Linux → Windows → registry regeneration. Extracted into `runAlpineTestsIfNeeded` to keep cyclomatic complexity within the project's lint budget.

### `pkg/start`
- After ensuring Linux + Windows containers, inspects the aggregated root `registry.yaml` and additionally ensures the Alpine container when libc is detected.

### `pkg/stop`
- Stops the Alpine container unconditionally. `StopContainer` is a no-op when nothing is running, so this guarantees cleanup even after a libc variant is removed from the registry.

### `go.mod`
- `github.com/google/go-cmp v0.7.0` promoted from indirect → direct (used by `pkg/libc/libc_test.go`). Already present in `go.sum` as a transitive dependency, so `go.sum` is unchanged.

## Out of scope

- Bumping `aqua/v2` to a release that exposes a public `Variants` Go type. Once available, `pkg/libc` can switch from the local struct to the upstream type; the rest of the wiring is unaffected.
- Auto-regeneration of the root `registry.yaml`. `argd t` still calls `genrg.GenerateRegistry()` at the end as before — `argd start` reads whatever is currently committed.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -covermode=atomic` (new `pkg/libc` tests pass with 95% coverage)
- [x] `golangci-lint run`
- [ ] e2e in `aqua-registry`:
  - [ ] `argd start -r` brings up `aqua-registry`, `aqua-registry-windows`, and `aqua-registry-alpine` only when the root `registry.yaml` contains `key: libc`.
  - [ ] `argd t <pkg>` for a `key: libc` package runs Debian linux/darwin → Alpine linux/{amd64,arm64} → Windows in that order, all green.
  - [ ] `argd s <pkg>` exercises the same Alpine step inside the scaffold flow.
  - [ ] `argd t <pkg>` for a non-libc package does not start the Alpine container.
  - [ ] `argd stop` stops all running containers (Alpine no-op when absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)