### PR TITLE
fix(gr): stabilize package order across case-insensitive filesystems

### DIFF
--- a/pkg/cli/gengr/command.go
+++ b/pkg/cli/gengr/command.go
@@ -20,8 +20,8 @@ Don't edit it manually, and if you update registry.yaml in the pkgs directory, d
 
 No argument is needed.
 `,
-		Action: func(context.Context, *cli.Command) error {
-			return genrg.GenerateRegistry()
+		Action: func(ctx context.Context, _ *cli.Command) error {
+			return genrg.GenerateRegistry(ctx)
 		},
 	}
 }

--- a/pkg/generate-registry/generate_registry.go
+++ b/pkg/generate-registry/generate_registry.go
@@ -2,9 +2,11 @@ package genrg
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -16,8 +18,8 @@ const rHeader = `---
 packages:
 `
 
-func GenerateRegistry() error {
-	registryFilePaths, err := listRegistryFiles()
+func GenerateRegistry(ctx context.Context) error {
+	registryFilePaths, err := listRegistryFiles(ctx)
 	if err != nil {
 		return err
 	}
@@ -41,7 +43,8 @@ func GenerateRegistry() error {
 	return nil
 }
 
-func listRegistryFiles() ([]string, error) {
+func listRegistryFiles(ctx context.Context) ([]string, error) {
+	canonical := canonicalCaseMap(ctx)
 	registryFilePaths := []string{}
 	if err := filepath.WalkDir("pkgs", func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -51,16 +54,41 @@ func listRegistryFiles() ([]string, error) {
 			return nil
 		}
 		if filepath.Base(p) == "registry.yaml" {
-			registryFilePaths = append(registryFilePaths, p)
+			slash := filepath.ToSlash(p)
+			if c, ok := canonical[strings.ToLower(slash)]; ok {
+				slash = c
+			}
+			registryFilePaths = append(registryFilePaths, slash)
 		}
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("find registry.yaml in the directory pkgs: %w", err)
 	}
 	sort.Slice(registryFilePaths, func(i, j int) bool {
-		return filepath.ToSlash(filepath.Dir(registryFilePaths[i])) < filepath.ToSlash(filepath.Dir(registryFilePaths[j]))
+		return filepath.Dir(registryFilePaths[i]) < filepath.Dir(registryFilePaths[j])
 	})
 	return registryFilePaths, nil
+}
+
+// canonicalCaseMap returns a lower-cased path → git-recorded path mapping for
+// every file tracked under pkgs/. On case-insensitive filesystems (APFS, NTFS)
+// the working tree may surface a different case than git's index, which would
+// otherwise make registry.yaml ordering depend on the contributor's machine.
+// Returns nil if git is unavailable or pkgs/ is not tracked.
+func canonicalCaseMap(ctx context.Context) map[string]string {
+	out, err := exec.CommandContext(ctx, "git", "ls-files", "-z", "--", "pkgs").Output()
+	if err != nil {
+		return nil
+	}
+	s := strings.TrimRight(string(out), "\x00")
+	if s == "" {
+		return nil
+	}
+	m := make(map[string]string)
+	for p := range strings.SplitSeq(s, "\x00") {
+		m[strings.ToLower(p)] = p
+	}
+	return m
 }
 
 func readRegistryFile(registryFilePath string) ([]string, error) {

--- a/pkg/resolve-conflict/resolve.go
+++ b/pkg/resolve-conflict/resolve.go
@@ -78,7 +78,7 @@ func mergeMainWithBackup(ctx context.Context, logger *slog.Logger) error {
 	}
 
 	// Regenerate registry.yaml
-	if err := genrg.GenerateRegistry(); err != nil {
+	if err := genrg.GenerateRegistry(ctx); err != nil {
 		return fmt.Errorf("generate registry: %w", err)
 	}
 

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -59,7 +59,7 @@ func scaffoldLocal(ctx context.Context, logger *slog.Logger, cfg *Config) error 
 	}
 
 	logger.Info("updating registry.yaml")
-	if err := genrg.GenerateRegistry(); err != nil {
+	if err := genrg.GenerateRegistry(ctx); err != nil {
 		return fmt.Errorf("update registry.yaml: %w", err)
 	}
 
@@ -102,7 +102,7 @@ func scaffoldFull(ctx context.Context, logger *slog.Logger, cfg *Config, githubT
 	}
 
 	logger.Info("Updating registry.yaml")
-	if err := genrg.GenerateRegistry(); err != nil {
+	if err := genrg.GenerateRegistry(ctx); err != nil {
 		return fmt.Errorf("update registry.yaml: %w", err)
 	}
 

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -62,7 +62,7 @@ func Test(ctx context.Context, logger *slog.Logger, cfg *Config) error {
 
 	// Update registry.yaml
 	logger.Info("Updating registry.yaml")
-	if err := genrg.GenerateRegistry(); err != nil {
+	if err := genrg.GenerateRegistry(ctx); err != nil {
 		return fmt.Errorf("update registry.yaml: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- On case-insensitive filesystems (APFS, NTFS) the working tree can surface a directory under a case that differs from git's index — e.g. `pkgs/DataDog/` (git's view) materializes as `pkgs/datadog/` on macOS after a flip. `filepath.WalkDir` emits the FS canonical case, so `argd gr` then sorts those entries into the lowercase-`d` section instead of the uppercase-`D` section, producing a huge phantom `registry.yaml` diff that is unique to that contributor's machine.
- Sort itself is byte-order (locale-independent); the discrepancy comes from the input strings being different. Normalizing each path to git's canonical case before sort makes the output identical on Linux CI and macOS regardless of working-tree case flips.
- Implementation: query `git ls-files -z -- pkgs` once, build a `lowercase-path → git-recorded path` map, and substitute the canonical case before sorting. Falls back to the working-tree case if git is unavailable or the file is untracked (e.g. freshly scaffolded packages not yet `git add`ed). `GenerateRegistry` now takes a `context.Context` to plumb cancellation into `exec.CommandContext`.

## Background

aquaproj/aqua-registry repro:

```
# before: APFS flipped pkgs/DataDog → pkgs/datadog (same inode, lowercase canonical)
$ /bin/ls -d pkgs/[Dd]ata[Dd]og
pkgs/datadog
$ argd gr   # released v0.5.2
$ git diff --stat registry.yaml
 registry.yaml | 206 ++++++++++++++++++++--   # 103 lines moved between sections
```

The DataDog packages get moved from the uppercase-D section (~line 2407) to right before `datanymizer` (~line 30095), purely because readdir returned a different string on macOS than on Linux CI.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean
- [x] `go test ./...` passes
- [x] Built locally and ran `argd gr` against `aquaproj/aqua-registry` with the FS canonical case flipped to `pkgs/datadog/` — produces **zero** `registry.yaml` diff (released v0.5.2 produces a 206-line phantom diff in the same state)
- [x] Same run with the FS canonical case at `pkgs/DataDog/` — also produces zero diff (no regression vs. v0.5.2 baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)