### PR TITLE
feat(scaffold)!: remove --local option

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -68,7 +68,6 @@ OPTIONS:
    --deep                      This flag was deprecated and had no meaning from aqua v2.15.0. This flag will be removed in aqua v3.0.0. https://github.com/aquaproj/aqua/issues/2351
    --cmd string                A list of commands joined with single quotes ','
    --limit int, -l int         the maximum number of versions (default: 0)
-   --local                     Run in local mode without Docker (simple scaffold only)
    --recreate, -r              Recreate Docker containers
    --no-create-branch, -B      Don't create a git branch
    --config string, -c string  Path to scaffold.yaml configuration file

--- a/USAGE.md
+++ b/USAGE.md
@@ -68,6 +68,7 @@ OPTIONS:
    --deep                      This flag was deprecated and had no meaning from aqua v2.15.0. This flag will be removed in aqua v3.0.0. https://github.com/aquaproj/aqua/issues/2351
    --cmd string                A list of commands joined with single quotes ','
    --limit int, -l int         the maximum number of versions (default: 0)
+   --local                     Run in local mode without Docker (simple scaffold only)
    --recreate, -r              Recreate Docker containers
    --no-create-branch, -B      Don't create a git branch
    --config string, -c string  Path to scaffold.yaml configuration file

--- a/pkg/cli/scaffold/command.go
+++ b/pkg/cli/scaffold/command.go
@@ -16,7 +16,6 @@ type scaffoldFlags struct {
 	Config         string
 	Limit          int
 	Deep           bool
-	Local          bool
 	Recreate       bool
 	NoCreateBranch bool
 }
@@ -50,7 +49,6 @@ func Command(logger *slog.Logger, gFlags *gflag.Flags) *cli.Command {
 				PkgName:        pkgName,
 				Cmds:           flags.Cmd,
 				Limit:          flags.Limit,
-				Local:          flags.Local,
 				Recreate:       flags.Recreate,
 				NoCreateBranch: flags.NoCreateBranch,
 				ConfigPath:     flags.Config,
@@ -78,11 +76,6 @@ func scaffoldCLIFlags(flags *scaffoldFlags) []cli.Flag {
 			Aliases:     []string{"l"},
 			Usage:       "the maximum number of versions",
 			Destination: &flags.Limit,
-		},
-		&cli.BoolFlag{
-			Name:        "local",
-			Usage:       "Run in local mode without Docker (simple scaffold only)",
-			Destination: &flags.Local,
 		},
 		&cli.BoolFlag{
 			Name:        "recreate",

--- a/pkg/scaffold/api.go
+++ b/pkg/scaffold/api.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -16,13 +15,11 @@ import (
 	"github.com/aquaproj/registry-tool/pkg/docker"
 	genrg "github.com/aquaproj/registry-tool/pkg/generate-registry"
 	"github.com/aquaproj/registry-tool/pkg/github"
-	"github.com/aquaproj/registry-tool/pkg/initcmd"
 	"github.com/aquaproj/registry-tool/pkg/libc"
-	"github.com/aquaproj/registry-tool/pkg/osexec"
 )
 
 // Scaffold is the main entry point for the scaffold command.
-// It supports both local mode (simple, no Docker) and full mode (Docker-based with tests).
+// It runs the Docker-based scaffold workflow with tests.
 func Scaffold(ctx context.Context, logger *slog.Logger, cfg *Config) error {
 	if cfg.PkgName == "" {
 		return errors.New(`usage: $ argd scaffold <pkgname>
@@ -37,37 +34,7 @@ e.g. $ argd scaffold cli/cli`)
 		return fmt.Errorf("get github access token: %w", err)
 	}
 
-	if cfg.Local {
-		return scaffoldLocal(ctx, logger, cfg)
-	}
 	return scaffoldFull(ctx, logger, cfg, githubToken)
-}
-
-// scaffoldLocal runs the simple local scaffold without Docker.
-func scaffoldLocal(ctx context.Context, logger *slog.Logger, cfg *Config) error {
-	pkgName := cfg.PkgName
-	pkgDir := filepath.Join(append([]string{"pkgs"}, strings.Split(pkgName, "/")...)...)
-	pkgFile := filepath.Join(pkgDir, "pkg.yaml")
-	rgFile := filepath.Join(pkgDir, "registry.yaml")
-
-	if err := os.MkdirAll(pkgDir, docker.DirPermission); err != nil {
-		return fmt.Errorf("create directories: %w", err)
-	}
-
-	if err := aquaGR(ctx, logger, pkgName, pkgFile, rgFile, cfg.Cmds, cfg.Limit, cfg.ConfigPath); err != nil {
-		return err
-	}
-
-	logger.Info("updating registry.yaml")
-	if err := genrg.GenerateRegistry(ctx); err != nil {
-		return fmt.Errorf("update registry.yaml: %w", err)
-	}
-
-	if err := initcmd.Init(ctx); err != nil {
-		return err //nolint:wrapcheck
-	}
-
-	return nil
 }
 
 // scaffoldFull runs the full scaffold workflow with Docker containers and tests.
@@ -274,40 +241,4 @@ func writeRegistryYAML(path string, data []byte) error {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-func aquaGR(ctx context.Context, logger *slog.Logger, pkgName, pkgFilePath, rgFilePath, cmds string, limit int, configPath string) error {
-	outFile, err := os.Create(rgFilePath)
-	if err != nil {
-		return fmt.Errorf("create a file %s: %w", rgFilePath, err)
-	}
-	defer outFile.Close()
-
-	if _, err := outFile.WriteString("# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json\n"); err != nil {
-		return fmt.Errorf("write a code comment for yaml-language-server: %w", err)
-	}
-
-	args := []string{"gr", "-out-testdata", pkgFilePath}
-
-	if cmds != "" {
-		args = append(args, "-cmd", cmds)
-	}
-	if limit != 0 {
-		s := strconv.Itoa(limit)
-		args = append(args, "-limit", s)
-	}
-	if configPath != "" {
-		args = append(args, "-c", configPath)
-	}
-
-	cmd := exec.CommandContext(ctx, "aqua", append(args, pkgName)...) //nolint:gosec
-	cmd.Stdout = outFile
-	cmd.Stderr = os.Stderr
-	osexec.SetCancel(logger, cmd)
-	logger.Info("+ " + cmd.String())
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("execute a command: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/scaffold/config.go
+++ b/pkg/scaffold/config.go
@@ -8,8 +8,6 @@ type Config struct {
 	Cmds string
 	// Limit is the maximum number of versions to generate
 	Limit int
-	// Local runs in local mode without Docker
-	Local bool
 	// Recreate forces recreation of Docker containers
 	Recreate bool
 	// NoCreateBranch skips creating a git branch


### PR DESCRIPTION
## Summary

Remove the `--local` flag from `argd scaffold` (alias `argd s`). After this change, `argd scaffold` always runs the Docker-based workflow, which:

- creates a **separate commit** for the auto-generated `pkg.yaml` / `registry.yaml`, so reviewers can clearly distinguish auto-generated content from hand edits, and
- runs **Linux / Darwin / Alpine (when `key: libc` is used) / Windows container tests**, providing a baseline quality guarantee.

`--local` skipped both of these, which made the resulting PRs harder to review and less reliable. Removing the flag closes that bypass.

## Changes

- `pkg/cli/scaffold/command.go` — drop the `Local` field on `scaffoldFlags`, the `--local` `BoolFlag`, and the corresponding entry in the `scaffold.Config` initializer.
- `pkg/scaffold/config.go` — drop the `Local bool` field on `Config`.
- `pkg/scaffold/api.go` — remove the `if cfg.Local` branch, the `scaffoldLocal` function, and the `aquaGR` helper that was only used by it. Update the `Scaffold` doc comment to reflect that the command now always runs the Docker-based workflow. Remove the now-unused `os/exec`, `github.com/aquaproj/registry-tool/pkg/initcmd`, and `github.com/aquaproj/registry-tool/pkg/osexec` imports.
- `USAGE.md` — remove the `--local` line from the `argd scaffold` options table.

## Breaking change

`argd scaffold --local` (and `argd s --local`) no longer exists. Callers should drop the flag and use `argd scaffold <pkg>` (or `argd s <pkg>`), which runs the full Docker flow. Docker is required as it already was for the default flow.

Without the --local option, additional requirements such as the docker command are needed for contributions, and I think that's acceptable.
Even if it raises the barrier to contribution somewhat, we should reduce the burden on the maintainer (i.e. me).

## Test plan

- [x] `go vet ./...`
- [x] `go test ./... -race -covermode=atomic`
- [x] `golangci-lint run` (no new findings on changed files)
- [ ] Manually run `argd scaffold <pkg>` end-to-end against a sample package once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)