### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,12 +5,14 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
       - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: docfresh -v
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}
@@ -18,6 +20,17 @@ jobs:
         env:
           AQUA_GITHUB_TOKEN: ${{github.token}}
       - run: docfresh run USAGE.md
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+      - name: Move the npmrc to the user npmrc
+        # Move the generated .npmrc to ~/.npmrc so `npm i -g` reads it and the
+        # auth token is not left in the working tree (autofix-ci commits changes).
+        run: |
+          if [ -f .npmrc ]; then
+            cat .npmrc >> "$HOME/.npmrc"
+            rm .npmrc
+          fi
       - run: npm i -g prettier
       - run: prettier -w .
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,13 +1,20 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://github.com/suzuki-shunsuke/ghalint) into the CI workflows for both Go and the npm install used by autofix.

## Changes

### `release.yaml`
- Pass `secrets.TAKUMI_GUARD_BOT_ID` (the reusable workflow is already at v8.1.0).

### `workflow_call_test.yaml`
- Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`).
- `test` job: bump `go-test-full-workflow` v5.0.2 → v6.0.0, pass the secret, add `id-token: write`.

### `test.yaml`
- `test` job: pass the secret and add `id-token: write`.

### `autofix.yaml`
- Go: add the `takumi_guard_bot_id` input and `id-token: write` (go-autofix-action already at v0.1.13).
- npm: add `setup-takumi-guard-npm@v1.1.1` before `npm i -g prettier`, moving the generated `.npmrc` to `$HOME/.npmrc` (so the global install reads it and the auth token is not left in the working tree for autofix-ci to commit).

## Note

- `go-test-full-workflow` crosses a **major** version (v5 → v6); please review CI for breaking changes.
- The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)