### PR TITLE
test: adapt to go-github v89 RepositoryRelease.ID

### DIFF
--- a/pkg/cli/listassets/command_internal_test.go
+++ b/pkg/cli/listassets/command_internal_test.go
@@ -37,8 +37,7 @@ func (m *mockGH) ListReleaseAssets(_ context.Context, _, _ string, _ int64, opts
 
 func Test_listAssets(t *testing.T) {
 	t.Parallel()
-	id := int64(1)
-	rel := &github.RepositoryRelease{ID: &id}
+	rel := &github.RepositoryRelease{ID: 1}
 
 	t.Run("release error", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Fixes the CI failure on #1778.

## Problem

`test / test / test / test` fails to build:

```
pkg/cli/listassets/command_internal_test.go:41:39: cannot use &id (value of type *int64) as int64 value in struct literal
```

## Cause

aqua v2.62.1 pulls in google/go-github v89, which changed `RepositoryRelease.ID` from `*int64` to `int64`. This test is the only place that constructs the field directly; production code reads it through the `Get*` accessors, which are unchanged.

## Change

```diff
-	id := int64(1)
-	rel := &github.RepositoryRelease{ID: &id}
+	rel := &github.RepositoryRelease{ID: 1}
```

`go build`, `go test`, `go vet` and `golangci-lint run` all pass locally.

This targets the Renovate branch rather than `main`, so review it here and it will land with #1778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)