### PR TITLE
fix: update argd documentation links

### DIFF
--- a/pkg/create-pr-new-pkg/api.go
+++ b/pkg/create-pr-new-pkg/api.go
@@ -64,7 +64,7 @@ func CreatePRNewPkgs(ctx context.Context, logger *slog.Logger, pkgName string) e
 	if err := commandStderr(ctx, io.MultiWriter(os.Stderr, stderr), "git", "push", "origin", branch); err != nil {
 		if strings.Contains(stderr.String(), "returned error: 403") {
 			logger.With(
-				"doc", "https://aquaproj.github.io/docs/products/aqua-registry/contributing#cmdx-new-fails-to-push-a-commit-to-the-origin",
+				"doc", "https://github.com/aquaproj/aqua-registry/blob/main/docs/troubleshooting.md",
 			).Warn(`you don't have the permission to push commits to the origin.
 Please fork aquaproj/aqua-registry and fix the origin url to your fork repository.
 For details, please see the document`)

--- a/pkg/create-pr-new-pkg/pr_template.md
+++ b/pkg/create-pr-new-pkg/pr_template.md
@@ -2,13 +2,13 @@
 
 <!-- Please check the list. Please don't remove the check list. -->
 
-- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
+- [ ] Read [CONTRIBUTING.md](https://github.com/aquaproj/aqua-registry/blob/main/CONTRIBUTING.md)
   - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
 - [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
   - This repository enables `Require signed commits`, so all commits must be signed
 - [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
 - [ ] Do only one thing in one Pull Request
-- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
+- [ ] [Execute argd s to scaffold code](https://github.com/aquaproj/aqua-registry/blob/main/docs/add_package.md#use-argd-s-definitely)
 - [ ] Install and execute the package and confirm if the package works well
 
 ## How to confirm if this package works well


### PR DESCRIPTION
## Summary

- replace the stale `cmdx s` checklist command with `argd s`
- point generated pull request guidance at the current aqua-registry contributing docs
- point the push-permission warning at the current troubleshooting document

## Why

The workflow moved from cmdx tasks to `argd`, and the contributing documentation moved into the aqua-registry repository. The generated pull request body and warning still referenced the old command and obsolete documentation fragments.

## Impact

Pull requests created by `argd new` now direct contributors to the current command and documentation.

## Validation

- `git diff --check`
- confirmed `pkg/create-pr-new-pkg` no longer contains the old cmdx guidance or moved contributing URL
- GitHub Actions passed, including commit signing, actionlint, typos, autofix, and the full test job
- local `go test ./... -race -covermode=atomic` dependency downloads were blocked by this environment's network allowlist for `proxy.golang.org`; GitHub Actions completed the same test job successfully
